### PR TITLE
Fix the issue #50 (Padding is not working properly on Android M)

### DIFF
--- a/library/src/main/java/com/mikepenz/iconics/view/IconicsImageView.java
+++ b/library/src/main/java/com/mikepenz/iconics/view/IconicsImageView.java
@@ -70,7 +70,7 @@ public class IconicsImageView extends ImageView {
 
             //set our values for this view
             setImageDrawable(mIcon);
-            setScaleType(ScaleType.MATRIX);
+            setScaleType(ScaleType.CENTER_INSIDE);
         }
     }
 


### PR DESCRIPTION
Change scaling type to use CENTER_INSIDE.
(Android M seems to have changed the behavior of MATRIX scaling type.)