### PR TITLE
Fix IconicsImageView icon size issue

### DIFF
--- a/app/src/main/res/layout/activity_playground.xml
+++ b/app/src/main/res/layout/activity_playground.xml
@@ -53,6 +53,48 @@
                     android:layout_height="72dp"
                     app:iiv_color="@android:color/holo_red_dark"
                     app:iiv_icon="gmd-favorite" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <!-- no padding and size -->
+                <com.mikepenz.iconics.view.IconicsImageView
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:background="#ffcccc"
+                    app:iiv_color="#666666"
+                    app:iiv_icon="faw-android"/>
+
+                <!-- android:iiv_size -->
+                <com.mikepenz.iconics.view.IconicsImageView
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:background="#ccffcc"
+                    app:iiv_color="#666666"
+                    app:iiv_icon="faw-android"
+                    app:iiv_size="16dp"/>
+
+                <!-- android:iiv_padding -->
+                <com.mikepenz.iconics.view.IconicsImageView
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:background="#ccccff"
+                    app:iiv_color="#666666"
+                    app:iiv_icon="faw-android"
+                    app:iiv_padding="16dp"/>
+
+                <!-- android:padding -->
+                <com.mikepenz.iconics.view.IconicsImageView
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:background="#ffffcc"
+                    android:padding="16dp"
+                    app:iiv_color="#666666"
+                    app:iiv_icon="faw-android"/>
+
             </LinearLayout>
 
             <TextView

--- a/library-core/src/main/java/com/mikepenz/iconics/view/IconicsImageView.java
+++ b/library-core/src/main/java/com/mikepenz/iconics/view/IconicsImageView.java
@@ -252,17 +252,4 @@ public class IconicsImageView extends ImageView {
         }
         return null;
     }
-
-    @Override
-    protected void onSizeChanged(int w, int h, int oldW, int oldH) {
-        super.onSizeChanged(w, h, oldW, oldH);
-        if (getDrawable() instanceof IconicsDrawable) {
-            //set the size
-            if (w > h) {
-                ((IconicsDrawable) getDrawable()).sizePx(w);
-            } else {
-                ((IconicsDrawable) getDrawable()).sizePx(h);
-            }
-        }
-    }
 }

--- a/library-core/src/main/java/com/mikepenz/iconics/view/IconicsImageView.java
+++ b/library-core/src/main/java/com/mikepenz/iconics/view/IconicsImageView.java
@@ -139,7 +139,7 @@ public class IconicsImageView extends ImageView {
         if (mSize != -1) {
             mIcon.sizePx(mSize);
         }
-        if (mSize != -1) {
+        if (mPadding != -1) {
             mIcon.paddingPx(mPadding);
         }
         if (mContourColor != 0) {


### PR DESCRIPTION
Hi. I noticed these two issues of the `IconicsImageView` and this PR fixes them.

1. The `iiv_padding` property is not applied properly
2. Icon is scaled to fit the view size on Android 6.0

I have confirmed this works properly on Android 2.3.7, 4.3, 4.4.3, 5.0.2 and 6.0. Thanks!


| 2.3.7 | 4.3 | 4.4.3 | 5.0.2 | 6.0 |
|-----|-----|-----|-----|-----|
| <img src="https://cloud.githubusercontent.com/assets/2552365/10475908/a3c6cb24-7283-11e5-8c71-ed173f1075d8.png" width="150" /> | <img src="https://cloud.githubusercontent.com/assets/2552365/10475838/ed68b3ba-7282-11e5-8e37-6149194d7dba.png" width="150" /> | <img src="https://cloud.githubusercontent.com/assets/2552365/10475819/c12d9388-7282-11e5-98e0-444d4a9b9db1.png" width="150" /> | <img src="https://cloud.githubusercontent.com/assets/2552365/10475839/ed691792-7282-11e5-8f3b-a32b22ee46fc.png" width="150" /> | <img src="https://cloud.githubusercontent.com/assets/2552365/10475820/c12e535e-7282-11e5-9c2c-c24a80eef960.png" width="150" /> |

