### PR TITLE
Add mappingPrefix validation

### DIFF
--- a/library-core/src/main/java/com/mikepenz/iconics/typeface/GenericFont.java
+++ b/library-core/src/main/java/com/mikepenz/iconics/typeface/GenericFont.java
@@ -30,8 +30,8 @@ import java.util.HashMap;
  * Created by mikepenz on 01.11.14.
  */
 public class GenericFont implements ITypeface {
-    private String mFontName = "GenericFont";
-    private String mAuthor = "GenericAuthor";
+    private String mFontName;
+    private String mAuthor;
     private String mMappingPrefix;
     private String mFontFile;
 
@@ -42,11 +42,13 @@ public class GenericFont implements ITypeface {
     }
 
     public GenericFont(String mappingPrefix, String fontFile) {
-        this.mMappingPrefix = mappingPrefix;
-        this.mFontFile = fontFile;
+        this("GenericFont", "GenericAuthor", mappingPrefix, fontFile);
     }
 
     public GenericFont(String fontName, String author, String mappingPrefix, String fontFile) {
+        if (mappingPrefix.length() != 3) {
+            new IllegalArgumentException("MappingPrefix must be 3 char long");
+        }
         this.mFontName = fontName;
         this.mAuthor = author;
         this.mMappingPrefix = mappingPrefix;


### PR DESCRIPTION
First of all, thanks for this great library. XD
So.. I added mappingPrefix validation in GenericFont constructor, because I overlooked the rule that `Create a new GenericFont by defining a 3 char long fontId...`  :fearful: 