### PR TITLE
Add a simple sanity check to registered fonts

### DIFF
--- a/library-core/src/main/java/com/mikepenz/iconics/Iconics.java
+++ b/library-core/src/main/java/com/mikepenz/iconics/Iconics.java
@@ -54,6 +54,7 @@ public final class Iconics {
             for (String fontsClassPath : fonts) {
                 try {
                     ITypeface typeface = (ITypeface) Class.forName(fontsClassPath).newInstance();
+                    validateFont(typeface);
                     FONTS.put(typeface.getMappingPrefix(), typeface);
                 } catch (Exception e) {
                     Log.e("Android-Iconics", "Can't init: " + fontsClassPath);
@@ -85,8 +86,20 @@ public final class Iconics {
      * @return
      */
     public static boolean registerFont(ITypeface font) {
+        validateFont(font);
+
         FONTS.put(font.getMappingPrefix(), font);
         return true;
+    }
+
+    /**
+     * Perform a basic sanity check for a font.
+     * @param font
+     */
+    private static void validateFont(ITypeface font) {
+        if(font.getMappingPrefix().length() != 3) {
+            throw new IllegalArgumentException("The mapping prefix of a font must be three characters long.");
+        }
     }
 
     /**


### PR DESCRIPTION
As proposed in issue #224, add a simple length check to the mapping prefix, to prevent confusing error messages if an incorrect length is used