### PR TITLE
Add support for color(ColorStateList) in IconicsDrawable

### DIFF
--- a/library-core/src/main/java/com/mikepenz/iconics/context/IconicsFactory.java
+++ b/library-core/src/main/java/com/mikepenz/iconics/context/IconicsFactory.java
@@ -1,6 +1,7 @@
 package com.mikepenz.iconics.context;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.support.v7.view.menu.ActionMenuItemView;
 import android.text.Editable;
@@ -96,7 +97,7 @@ class IconicsFactory {
      * @return
      */
     IconicsDrawable getDrawable(Context context, final TypedArray a, String icon) {
-        int color = a.getColor(R.styleable.Iconics_ico_color, 0);
+        ColorStateList colors = a.getColorStateList(R.styleable.Iconics_ico_color);
         int size = a.getDimensionPixelSize(R.styleable.Iconics_ico_size, -1);
         int offsetX = a.getDimensionPixelSize(R.styleable.Iconics_ico_offset_x, -1);
         int offsetY = a.getDimensionPixelSize(R.styleable.Iconics_ico_offset_y, -1);
@@ -108,8 +109,8 @@ class IconicsFactory {
 
         IconicsDrawable drawable = new IconicsDrawable(context, icon);
 
-        if (color != 0) {
-            drawable.color(color);
+        if (colors != null) {
+            drawable.color(colors);
         }
         if (size != -1) {
             drawable.sizePx(size);


### PR DESCRIPTION
This adds support for `IconicsDrawable.color(ColorStateList colors)` to set multiple state dependent colors. It should be fully backwards compatible since every `int`-color can be converted to a `ColorStateList` and the [TypedArray.getColorStateList](https://developer.android.com/reference/android/content/res/TypedArray.html#getColorStateList(int)) used in `IconicsFactory` works on both, simple integer colors and state lists.
I had to introduce a update method that is very similar to how `TextView` does its updating.

Any feedback? Is this a welcomed addition?