### PR TITLE
Fix TextView example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Some great text with a {faw-android} font awesome icon and {met-wind} meteocons 
 ### As TextView (only available if you inject the context)
 ```xml
 <TextView
-    android:text="{gmd-chart} Chart"
+    android:text="{gmd-bubble-chart} Chart"
     android:textColor="@android:color/black"
     android:layout_width="wrap_content"
     android:layout_height="56dp"


### PR DESCRIPTION
I was wondering why the TextView example from the readme was not working, until I figured out that the icon `gmd-chart` does not exist. I updated it to `gmd-bubble-chart`.