### PR TITLE
Fix exception when closing empty path

### DIFF
--- a/library-core/src/main/java/com/mikepenz/iconics/IconicsDrawable.java
+++ b/library-core/src/main/java/com/mikepenz/iconics/IconicsDrawable.java
@@ -1090,7 +1090,9 @@ public class IconicsDrawable extends Drawable {
                 }
             }
 
-            mPath.close();
+            if (!mPath.isEmpty()) {
+                mPath.close();
+            }
 
             if (mDrawContour) {
                 canvas.drawPath(mPath, mContourPaint);
@@ -1127,7 +1129,9 @@ public class IconicsDrawable extends Drawable {
     @Override
     protected void onBoundsChange(Rect bounds) {
         offsetIcon(bounds);
-        mPath.close();
+        if (!mPath.isEmpty()) {
+            mPath.close();
+        }
         super.onBoundsChange(bounds);
     }
 


### PR DESCRIPTION
It happens when you open Android studio's layout preview where some of your views try to use IconicsDrawable. Because layout preview doesn't support Paint.getTextPath(), path itself will be empty, and when you try to close it, it throws the exception.

Simple fix is to check if path is not empty before trying to close it.