### PR TITLE
Fix the IconicsMenuInflaterUtil to be able to handle non literal ids

### DIFF
--- a/library-core/src/main/java/com/mikepenz/iconics/utils/IconicsMenuInflaterUtil.java
+++ b/library-core/src/main/java/com/mikepenz/iconics/utils/IconicsMenuInflaterUtil.java
@@ -112,7 +112,17 @@ public class IconicsMenuInflaterUtil {
                             }
                             IconicsDrawable icon = IconicsAttrsApplier.getIconicsDrawable(context, attrs);
                             if (icon != null) {
-                                int id = Integer.parseInt(attrsMap.get("id").replace("@", ""));
+                                String idAsString = attrsMap.get("id").replace("@", "");
+                                int id;
+
+                                // If the id is not in literal format, look it up using the name.
+                                if (idAsString.startsWith("+id/")) {
+                                    String name = idAsString.replace("+id/", "");
+                                    id = context.getResources().getIdentifier(name, "id", context.getPackageName());
+                                } else {
+                                    id = Integer.parseInt(idAsString);
+                                }
+
                                 menu.findItem(id).setIcon(icon);
                             }
                             break;
@@ -120,7 +130,7 @@ public class IconicsMenuInflaterUtil {
                         case XML_MENU:
                             // TODO: maybe we must pass in the sub menu in this case, not sure if the function menu.findItem(id) will search through sub items
                             if (checkSubMenus) {
-                                parseMenu(context, attrs, parser, menu, checkSubMenus);
+                                parseMenu(context, attrs, parser, menu, true);
                             }
                             break;
 


### PR DESCRIPTION
This fixes non literal ids in menus leading to a crash.
Happens in app bundles and is also reproducable in the sample app when building an app bundle and navigating to the playground.

Fixes #391. Thanks @MFlisar for the fix, this is basically what you commented!