### PR TITLE
Fixed crash on 4.1 (#436)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     }

--- a/library-core/src/main/java/com/mikepenz/iconics/animation/IconicsAnimationProcessor.java
+++ b/library-core/src/main/java/com/mikepenz/iconics/animation/IconicsAnimationProcessor.java
@@ -136,27 +136,6 @@ public abstract class IconicsAnimationProcessor {
         }
     };
 
-    @RequiresApi(Build.VERSION_CODES.KITKAT)
-    private final Animator.AnimatorPauseListener mProxyPauseListener = new Animator.AnimatorPauseListener() {
-
-        @Override
-        public void onAnimationPause(Animator animation) {
-            forEachListeners(l -> l.onAnimationPause(IconicsAnimationProcessor.this));
-        }
-
-        @Override
-        public void onAnimationResume(Animator animation) {
-            forEachListeners(l -> l.onAnimationResume(IconicsAnimationProcessor.this));
-        }
-
-        private void forEachListeners(Consumer<IconicsAnimationPauseListener> consumer) {
-            if (mPauseListeners == null) return;
-            for (IconicsAnimationPauseListener l : mPauseListeners) {
-                consumer.accept(l);
-            }
-        }
-    };
-
     /**
      * @return Tag which will be used to apply this processor via xml
      */
@@ -296,7 +275,25 @@ public abstract class IconicsAnimationProcessor {
     public IconicsAnimationProcessor addPauseListener(@NonNull IconicsAnimationPauseListener listener) {
         if (mPauseListeners == null) {
             mPauseListeners = new ArrayList<>();
-            mAnimator.addPauseListener(mProxyPauseListener);
+            mAnimator.addPauseListener(new Animator.AnimatorPauseListener() {
+
+                @Override
+                public void onAnimationPause(Animator animation) {
+                    forEachListeners(l -> l.onAnimationPause(IconicsAnimationProcessor.this));
+                }
+
+                @Override
+                public void onAnimationResume(Animator animation) {
+                    forEachListeners(l -> l.onAnimationResume(IconicsAnimationProcessor.this));
+                }
+
+                private void forEachListeners(Consumer<IconicsAnimationPauseListener> consumer) {
+                    if (mPauseListeners == null) return;
+                    for (IconicsAnimationPauseListener l : mPauseListeners) {
+                        consumer.accept(l);
+                    }
+                }
+            });
         }
         mPauseListeners.add(listener);
         return this;
@@ -316,7 +313,6 @@ public abstract class IconicsAnimationProcessor {
         mPauseListeners.remove(listener);
         if (mPauseListeners.size() == 0) {
             mPauseListeners = null;
-            mAnimator.removePauseListener(mProxyPauseListener);
         }
     }
 
@@ -334,7 +330,6 @@ public abstract class IconicsAnimationProcessor {
             if (mPauseListeners != null) {
                 mPauseListeners.clear();
                 mPauseListeners = null;
-                mAnimator.removePauseListener(mProxyPauseListener);
             }
         }
     }


### PR DESCRIPTION
 - Updated build tools version
 - Fixed crash on 4.1 when platform (less than 4.4) cant find `android.animation.Animator.AnimatorPauseListener` (added since 4.4) #436