### PR TITLE
Sealed classes for IconicsColor and IconicsSize

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,10 +77,10 @@ android {
 dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    implementation "androidx.appcompat:appcompat:${versions.appCompat}"
-    implementation "com.google.android.material:material:${versions.androidX}"
-    implementation "androidx.recyclerview:recyclerview:${versions.androidX}"
-    implementation "androidx.cardview:cardview:${versions.androidX}"
+    implementation "androidx.appcompat:appcompat:${versions.appcompat}"
+    implementation "com.google.android.material:material:${versions.material}"
+    implementation "androidx.recyclerview:recyclerview:${versions.recyclerView}"
+    implementation "androidx.cardview:cardview:${versions.cardview}"
 
     // used to base on some backwards compatible themes
     // contains util classes to support various android versions, and clean up code
@@ -91,10 +91,10 @@ dependencies {
     // used to fill the RecyclerView with the DrawerItems
     // and provides single and multi selection, expandable items
     // https://github.com/mikepenz/FastAdapter
-    implementation 'com.mikepenz:fastadapter:4.0.0-rc03'
-    implementation 'com.mikepenz:fastadapter-extensions-utils:4.0.0-rc03'
-    implementation 'com.mikepenz:fastadapter-extensions-ui:4.0.0-rc03'
-    implementation 'com.mikepenz:fastadapter-extensions-expandable:4.0.0-rc03'
+    implementation 'com.mikepenz:fastadapter:4.0.0'
+    implementation 'com.mikepenz:fastadapter-extensions-utils:4.0.0'
+    implementation 'com.mikepenz:fastadapter-extensions-ui:4.0.0'
+    implementation 'com.mikepenz:fastadapter-extensions-expandable:4.0.0'
 
     // used to generating string fields for icons (sample - test/java/StringFieldGenerator.java)
     // https://github.com/zTrap/Android-Iconics-String-Generator
@@ -102,7 +102,7 @@ dependencies {
 
     // used to generate the drawer on the left
     // https://github.com/mikepenz/MaterialDrawer
-    implementation('com.mikepenz:materialdrawer:7.0.0-beta01') {
+    implementation('com.mikepenz:materialdrawer:7.0.0-rc01') {
         transitive = true
         exclude module: "fastadapter"
         exclude module: "fastadapter-extensions-expandable"
@@ -111,7 +111,7 @@ dependencies {
 
     // used to generate the Open Source section
     // https://github.com/mikepenz/AboutLibraries
-    implementation('com.mikepenz:aboutlibraries:7.0.0-rc1') {
+    implementation('com.mikepenz:aboutlibraries:7.0.0') {
         transitive = true
         exclude module: "fastadapter"
         exclude module: "iconics-core"

--- a/app/src/main/java/com/mikepenz/iconics/sample/IconsFragment.kt
+++ b/app/src/main/java/com/mikepenz/iconics/sample/IconsFragment.kt
@@ -34,14 +34,20 @@ import androidx.recyclerview.widget.RecyclerView
 import com.mikepenz.fastadapter.adapters.FastItemAdapter
 import com.mikepenz.fastadapter.listeners.OnBindViewHolderListener
 import com.mikepenz.iconics.Iconics
+import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.IconicsSize
 import com.mikepenz.iconics.sample.item.IconItem
 import com.mikepenz.iconics.utils.IconicsUtils
+import com.mikepenz.iconics.utils.backgroundColorRes
+import com.mikepenz.iconics.utils.backgroundColorString
+import com.mikepenz.iconics.utils.colorRes
+import com.mikepenz.iconics.utils.contourColorRes
+import com.mikepenz.iconics.utils.contourWidthDp
 import com.mikepenz.iconics.utils.enableShadowSupport
-import com.mikepenz.iconics.utils.toIconicsColor
-import com.mikepenz.iconics.utils.toIconicsColorRes
-import com.mikepenz.iconics.utils.toIconicsSizeDp
+import com.mikepenz.iconics.utils.paddingDp
+import com.mikepenz.iconics.utils.roundedCornersDp
+import com.mikepenz.iconics.utils.sizeDp
 import kotlinx.android.synthetic.main.icons_fragment.list
 import java.util.ArrayList
 import java.util.Random
@@ -125,10 +131,10 @@ class IconsFragment : Fragment() {
                 if (i != null) {
                     val icon = IconicsDrawable(ctx)
                             .icon(i)
-                            .size(IconicsSize.dp(144f))
-                            .padding(IconicsSize.dp(8f))
-                            .backgroundColor("#DDFFFFFF".toIconicsColor())
-                            .roundedCorners(IconicsSize.dp(12f))
+                            .sizeDp(144)
+                            .paddingDp(8)
+                            .backgroundColorString("#DDFFFFFF")
+                            .roundedCornersDp(12)
 
                     ImageView(ctx).let { imageView ->
                         imageView.setImageDrawable(icon)
@@ -179,15 +185,15 @@ class IconsFragment : Fragment() {
 
                     holder.image.icon?.let {
                         if (randomize) {
-                            it.color(getRandomColor(position).toIconicsColorRes())
-                                    .padding(random.nextInt(12).toIconicsSizeDp())
-                                    .contourWidth(random.nextInt(2).toIconicsSizeDp())
-                                    .contourColor(getRandomColor(position - 2).toIconicsColor())
+                            it.colorRes(getRandomColor(position))
+                                    .paddingDp(random.nextInt(12))
+                                    .contourWidthDp(random.nextInt(2))
+                                    .contourColorRes(getRandomColor(position - 2))
 
                             val y = random.nextInt(10)
                             if (y % 4 == 0) {
-                                it.backgroundColor(getRandomColor(position - 4).toIconicsColorRes())
-                                        .roundedCorners((2 + random.nextInt(10)).toIconicsSizeDp())
+                                it.backgroundColorRes(getRandomColor(position - 4))
+                                        .roundedCorners(IconicsSize.dp((2 + random.nextInt(10))))
                             }
                         }
                     }
@@ -196,10 +202,10 @@ class IconsFragment : Fragment() {
                         holder.image.enableShadowSupport()
                         //holder.image.getIcon().shadowDp(1, 1, 1, Color.argb(200, 0, 0, 0));
                         holder.image.icon?.shadow(
-                            radius = 1.toIconicsSizeDp(),
-                            dx = 1.toIconicsSizeDp(),
-                            dy = 1.toIconicsSizeDp(),
-                            color = Color.argb(200, 0, 0, 0).toIconicsColor()
+                            radius = IconicsSize.dp(1),
+                            dx = IconicsSize.dp(1),
+                            dy = IconicsSize.dp(1),
+                            color = IconicsColor.colorInt(Color.argb(200, 0, 0, 0))
                         )
                     }
                 }

--- a/app/src/main/java/com/mikepenz/iconics/sample/MainActivity.kt
+++ b/app/src/main/java/com/mikepenz/iconics/sample/MainActivity.kt
@@ -28,12 +28,12 @@ import com.mikepenz.aboutlibraries.Libs
 import com.mikepenz.aboutlibraries.LibsBuilder
 import com.mikepenz.iconics.Iconics
 import com.mikepenz.iconics.IconicsDrawable
-import com.mikepenz.iconics.colorInt
-import com.mikepenz.iconics.sizeDp
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.library.fontawesome.FontAwesome
 import com.mikepenz.iconics.typeface.library.materialdesigniconic.MaterialDesignIconic
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import com.mikepenz.materialdrawer.Drawer
 import com.mikepenz.materialdrawer.DrawerBuilder
 import com.mikepenz.materialdrawer.holder.BadgeStyle
@@ -86,7 +86,11 @@ class MainActivity : AppCompatActivity() {
                 .withToolbar(toolbar)
                 .withDrawerItems(items)
                 .withOnDrawerItemClickListener(object : Drawer.OnDrawerItemClickListener {
-                    override fun onItemClick(view: View?, position: Int, drawerItem: IDrawerItem<*>): Boolean {
+                    override fun onItemClick(
+                        view: View?,
+                        position: Int,
+                        drawerItem: IDrawerItem<*>
+                    ): Boolean {
                         fonts[position].fontName.also {
                             loadIcons(it)
                             supportActionBar?.title = it

--- a/app/src/main/java/com/mikepenz/iconics/sample/PlaygroundActivity.kt
+++ b/app/src/main/java/com/mikepenz/iconics/sample/PlaygroundActivity.kt
@@ -38,16 +38,16 @@ import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
 import com.mikepenz.iconics.Iconics
 import com.mikepenz.iconics.IconicsArrayBuilder
+import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
-import com.mikepenz.iconics.paddingDp
-import com.mikepenz.iconics.sizeDp
+import com.mikepenz.iconics.IconicsSize
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.typeface.library.fontawesome.FontAwesome
 import com.mikepenz.iconics.typeface.library.octicons.Octicons
 import com.mikepenz.iconics.utils.inflateWithIconics
+import com.mikepenz.iconics.utils.paddingDp
 import com.mikepenz.iconics.utils.parseXmlAndSetIconicsDrawables
-import com.mikepenz.iconics.utils.toIconicsColor
-import com.mikepenz.iconics.utils.toIconicsSizeDp
+import com.mikepenz.iconics.utils.sizeDp
 import kotlinx.android.synthetic.main.activity_playground.list
 import kotlinx.android.synthetic.main.activity_playground.navigation
 import kotlinx.android.synthetic.main.activity_playground.navigation_auto
@@ -101,19 +101,19 @@ class PlaygroundActivity : AppCompatActivity() {
         //Set the icon of an ImageView (or something else) as drawable
         test2.setImageDrawable(
             IconicsDrawable(this, FontAwesome.Icon.faw_thumbs_up)
-                    .size(48.toIconicsSizeDp())
-                    .color("#aaFF0000".toIconicsColor())
-                    .contourWidth(1.toIconicsSizeDp())
+                    .size(IconicsSize.dp(48))
+                    .color(IconicsColor.parse("#aaFF0000"))
+                    .contourWidth(IconicsSize.dp(1))
         )
 
         //Set the icon of an ImageView (or something else) as bitmap
         test3.setImageBitmap(
             IconicsDrawable(this, FontAwesome.Icon.faw_android)
-                    .sizeX(48.toIconicsSizeDp())
-                    .sizeY(32.toIconicsSizeDp())
-                    .padding(4.toIconicsSizeDp())
-                    .roundedCorners(8.toIconicsSizeDp())
-                    .color("#deFF0000".toIconicsColor())
+                    .sizeX(IconicsSize.dp(48))
+                    .sizeY(IconicsSize.dp(32))
+                    .padding(IconicsSize.dp(4))
+                    .roundedCorners(IconicsSize.dp(8))
+                    .color(IconicsColor.parse("#deFF0000"))
                     .toBitmap()
         )
 
@@ -130,23 +130,23 @@ class PlaygroundActivity : AppCompatActivity() {
         iconStateListDrawable.addState(
             intArrayOf(android.R.attr.state_pressed),
             IconicsDrawable(this, FontAwesome.Icon.faw_thumbs_up)
-                    .size(48.toIconicsSizeDp())
-                    .color("#aaFF0000".toIconicsColor())
-                    .contourWidth(1.toIconicsSizeDp())
+                    .size(IconicsSize.dp(48))
+                    .color(IconicsColor.parse("#aaFF0000"))
+                    .contourWidth(IconicsSize.dp(1))
         )
         iconStateListDrawable.addState(
             intArrayOf(),
             IconicsDrawable(this, FontAwesome.Icon.faw_thumbs_up)
-                    .size(48.toIconicsSizeDp())
-                    .color("#aa00FF00".toIconicsColor())
-                    .contourWidth(2.toIconicsSizeDp())
+                    .size(IconicsSize.dp(48))
+                    .color(IconicsColor.parse("#aa00FF00"))
+                    .contourWidth(IconicsSize.dp(2))
         )
         test6.setImageDrawable(iconStateListDrawable)
 
         val iconicsDrawableBase = IconicsDrawable(this)
                 .actionBar()
-                .color(Color.GREEN.toIconicsColor())
-                .backgroundColor(Color.RED.toIconicsColor())
+                .color(IconicsColor.colorInt(Color.GREEN))
+                .backgroundColor(IconicsColor.colorInt(Color.RED))
         val array = IconicsArrayBuilder(iconicsDrawableBase)
                 .add(FontAwesome.Icon.faw_android)
                 .add(Octicons.Icon.oct_octoface)

--- a/app/src/main/java/com/mikepenz/iconics/sample/item/IconItem.kt
+++ b/app/src/main/java/com/mikepenz/iconics/sample/item/IconItem.kt
@@ -24,8 +24,8 @@ import com.mikepenz.fastadapter.items.AbstractItem
 import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.IconicsSize
-import com.mikepenz.iconics.colorInt
 import com.mikepenz.iconics.sample.R
+import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.view.IconicsImageView
 
 /**

--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,15 @@ buildscript {
         ]
 
         versions = [
-                kotlin   : '1.3.31',
-                androidX : '1.0.0',
-                appCompat: '1.0.2',
-                ktx      : [
+                kotlin          : '1.3.31',
+                androidX        : '1.0.0',
+                recyclerView    : '1.1.0-alpha06',
+                material        : '1.1.0-alpha07',
+                appcompat       : '1.1.0-beta01',
+                drawerlayout    : '1.1.0-alpha01',
+                constraintLayout: '2.0.0-beta1',
+                cardview        : '1.0.0',
+                ktx             : [
                         core: '1.0.2'
                 ]
         ]

--- a/iconics-view-library/build.gradle
+++ b/iconics-view-library/build.gradle
@@ -51,7 +51,7 @@ if (project.hasProperty('pushall') || project.hasProperty('libraryviewsonly')) {
 
 dependencies {
     implementation project(':library-core')
-    implementation "androidx.appcompat:appcompat:$versions.appCompat"
+    implementation "androidx.appcompat:appcompat:$versions.appcompat"
     implementation "androidx.core:core-ktx:$versions.ktx.core"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
 }

--- a/library-core/build.gradle
+++ b/library-core/build.gradle
@@ -52,7 +52,7 @@ if (project.hasProperty('pushall') || project.hasProperty('librarycoreonly')) {
 }
 
 dependencies {
-    implementation "androidx.appcompat:appcompat:$versions.appCompat"
+    implementation "androidx.appcompat:appcompat:$versions.appcompat"
     implementation "androidx.core:core-ktx:$versions.ktx.core"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$versions.kotlin"
 }

--- a/library-core/src/main/java/com/mikepenz/iconics/IconicsColor.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/IconicsColor.kt
@@ -62,13 +62,13 @@ sealed class IconicsColor {
     internal abstract fun extract(context: Context): Int
 }
 
-class IconicsColorInt internal constructor(private val color: Int) : IconicsColor() {
+class IconicsColorInt internal constructor(@ColorInt private val color: Int) : IconicsColor() {
     override fun extractList(context: Context): ColorStateList? = ColorStateList.valueOf(color)
 
     override fun extract(context: Context): Int = color
 }
 
-class IconicsColorRes internal constructor(private val colorRes: Int) : IconicsColor() {
+class IconicsColorRes internal constructor(@ColorRes private val colorRes: Int) : IconicsColor() {
     override fun extractList(context: Context): ColorStateList? =
             ContextCompat.getColorStateList(context, colorRes)
 

--- a/library-core/src/main/java/com/mikepenz/iconics/IconicsColor.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/IconicsColor.kt
@@ -24,25 +24,24 @@ import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
 
 /**
- * @author pa.gulko zTrap (20.01.2018)
+ * Describes a color. Might be a colorInt, colorRes, or colorStateList
  */
-class IconicsColor private constructor() : IconicsExtractor {
-
+sealed class IconicsColor {
     companion object {
 
         /** @param colorInt The color, usually from [android.graphics.Color] or 0xFF012345. */
         @JvmStatic fun colorInt(@ColorInt colorInt: Int): IconicsColor {
-            return IconicsColor().also { it.colorInt = colorInt }
+            return IconicsColorInt(colorInt)
         }
 
         /** @param colorRes The color resource, from your R file. */
         @JvmStatic fun colorRes(@ColorRes colorRes: Int): IconicsColor {
-            return IconicsColor().also { it.colorRes = colorRes }
+            return IconicsColorRes(colorRes)
         }
 
         /** @param colorList The color state list. */
         @JvmStatic fun colorList(colorList: ColorStateList): IconicsColor {
-            return IconicsColor().also { it.colorList = colorList }
+            return IconicsColorList(colorList)
         }
 
         /**
@@ -58,25 +57,29 @@ class IconicsColor private constructor() : IconicsExtractor {
         }
     }
 
-    private var colorList: ColorStateList? = null
-    @ColorInt private var colorInt: Int = IconicsExtractor.DEF_COLOR
-    @ColorRes private var colorRes: Int = IconicsExtractor.DEF_RESOURCE
+    internal abstract fun extractList(context: Context): ColorStateList?
 
-    internal fun extractList(context: Context): ColorStateList? {
-        var colorStateList = colorList
-        if (colorRes != IconicsExtractor.DEF_RESOURCE) {
-            colorStateList = ContextCompat.getColorStateList(context, colorRes)
-        }
-        if (colorInt != IconicsExtractor.DEF_COLOR) {
-            colorStateList = ColorStateList.valueOf(colorInt)
-        }
-        return colorStateList
-    }
+    internal abstract fun extract(context: Context): Int
+}
 
-    internal fun extract(context: Context): Int {
-        if (colorRes != IconicsExtractor.DEF_RESOURCE) {
-            colorInt = ContextCompat.getColor(context, colorRes)
-        }
-        return colorInt
-    }
+class IconicsColorInt internal constructor(private val color: Int) : IconicsColor() {
+    override fun extractList(context: Context): ColorStateList? = ColorStateList.valueOf(color)
+
+    override fun extract(context: Context): Int = color
+}
+
+class IconicsColorRes internal constructor(private val colorRes: Int) : IconicsColor() {
+    override fun extractList(context: Context): ColorStateList? =
+            ContextCompat.getColorStateList(context, colorRes)
+
+    override fun extract(context: Context): Int =
+            ContextCompat.getColorStateList(context, colorRes)?.defaultColor
+                    ?: ContextCompat.getColor(context, colorRes)
+}
+
+class IconicsColorList internal constructor(private val colorList: ColorStateList) : IconicsColor() {
+    override fun extractList(context: Context): ColorStateList? = colorList
+
+    override fun extract(context: Context): Int =
+            colorList.defaultColor // use the default color in this case
 }

--- a/library-core/src/main/java/com/mikepenz/iconics/IconicsColor.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/IconicsColor.kt
@@ -72,9 +72,7 @@ class IconicsColorRes internal constructor(private val colorRes: Int) : IconicsC
     override fun extractList(context: Context): ColorStateList? =
             ContextCompat.getColorStateList(context, colorRes)
 
-    override fun extract(context: Context): Int =
-            ContextCompat.getColorStateList(context, colorRes)?.defaultColor
-                    ?: ContextCompat.getColor(context, colorRes)
+    override fun extract(context: Context): Int = ContextCompat.getColor(context, colorRes)
 }
 
 class IconicsColorList internal constructor(private val colorList: ColorStateList) : IconicsColor() {

--- a/library-core/src/main/java/com/mikepenz/iconics/IconicsDrawable.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/IconicsDrawable.kt
@@ -218,32 +218,37 @@ open class IconicsDrawable(protected val context: Context) : Drawable() {
 
     private fun <T : IconicsDrawable> copyTo(other: T): T {
         // icon
-        other.color { colorList?.toIconicsColor() }
-                .sizeX(sizeX.toIconicsSizePx())
-                .sizeY(sizeY.toIconicsSizePx())
-                .iconOffsetX(iconOffsetX.toIconicsSizePx())
-                .iconOffsetY(iconOffsetY.toIconicsSizePx())
-                .padding(iconPadding.toIconicsSizePx())
+        colorList?.also { other.color(IconicsColor.colorList(it)) }
+        // background
+        backgroundColorList?.also { other.backgroundColor(IconicsColor.colorList(it)) }
+        // icon contour
+        contourColorList?.also { other.contourColor(IconicsColor.colorList(it)) }
+        // background contour
+        backgroundContourColorList?.also { other.backgroundContourColor(IconicsColor.colorList(it)) }
+
+        // icon
+        other.sizeX(IconicsSize.px(sizeX))
+                .sizeY(IconicsSize.px(sizeY))
+                .iconOffsetX(IconicsSize.px(iconOffsetX))
+                .iconOffsetY(IconicsSize.px(iconOffsetY))
+                .padding(IconicsSize.px(iconPadding))
                 .typeface(iconBrush.paint.typeface)
                 .respectFontBounds(isRespectFontBounds)
                 // background
-                .backgroundColor { backgroundColorList?.toIconicsColor() }
-                .roundedCornersRx(roundedCornerRx.toIconicsSizePx())
-                .roundedCornersRy(roundedCornerRy.toIconicsSizePx())
+                .roundedCornersRx(IconicsSize.px(roundedCornerRx))
+                .roundedCornersRy(IconicsSize.px(roundedCornerRy))
                 // icon contour
-                .contourColor { contourColorList?.toIconicsColor() }
-                .contourWidth(contourWidth.toIconicsSizePx())
+                .contourWidth(IconicsSize.px(contourWidth))
                 .drawContour(isDrawContour)
                 // background contour
-                .backgroundContourColor { backgroundContourColorList?.toIconicsColor() }
-                .backgroundContourWidth(backgroundContourWidth.toIconicsSizePx())
+                .backgroundContourWidth(IconicsSize.px(backgroundContourWidth))
                 .drawBackgroundContour(isDrawBackgroundContour)
                 // shadow
                 .shadow(
-                    shadowRadius.toIconicsSizePx(),
-                    shadowDx.toIconicsSizePx(),
-                    shadowDy.toIconicsSizePx(),
-                    shadowColor.toIconicsColor()
+                    IconicsSize.px(shadowRadius),
+                    IconicsSize.px(shadowDx),
+                    IconicsSize.px(shadowDy),
+                    IconicsColor.colorInt(shadowColor)
                 )
                 // common
                 .alpha(compatAlpha)
@@ -763,10 +768,10 @@ open class IconicsDrawable(protected val context: Context) : Drawable() {
      * @see clearShadow
      */
     fun shadow(
-        radiusProducer: () -> IconicsSize? = { shadowRadius.toIconicsSizePx() },
-        dxProducer: () -> IconicsSize? = { shadowDx.toIconicsSizePx() },
-        dyProducer: () -> IconicsSize? = { shadowDy.toIconicsSizePx() },
-        colorProducer: () -> IconicsColor? = { shadowColor.toIconicsColor() }
+        radiusProducer: () -> IconicsSize? = { IconicsSize.px(shadowRadius) },
+        dxProducer: () -> IconicsSize? = { IconicsSize.px(shadowDx) },
+        dyProducer: () -> IconicsSize? = { IconicsSize.px(shadowDy) },
+        colorProducer: () -> IconicsColor? = { IconicsColor.colorInt(shadowColor) }
     ): IconicsDrawable {
         val radius = radiusProducer()
         val dx = dxProducer()
@@ -790,10 +795,10 @@ open class IconicsDrawable(protected val context: Context) : Drawable() {
      * @see clearShadow
      */
     fun shadow(
-        radius: IconicsSize = shadowRadius.toIconicsSizePx(),
-        dx: IconicsSize = shadowDx.toIconicsSizePx(),
-        dy: IconicsSize = shadowDy.toIconicsSizePx(),
-        color: IconicsColor = shadowColor.toIconicsColor()
+        radius: IconicsSize = IconicsSize.px(shadowRadius),
+        dx: IconicsSize = IconicsSize.px(shadowDx),
+        dy: IconicsSize = IconicsSize.px(shadowDy),
+        color: IconicsColor = IconicsColor.colorInt(shadowColor)
     ): IconicsDrawable {
         shadowRadius = radius.extractFloat(context)
         shadowDx = dx.extractFloat(context)
@@ -1212,23 +1217,65 @@ open class IconicsDrawable(protected val context: Context) : Drawable() {
 }
 
 // VARIOUS convenient extension functions for quick common setters
+@Deprecated(
+    message = "Moved to new class",
+    replaceWith = ReplaceWith("colorString", "com.mikepenz.iconics.utils.colorString")
+)
+inline fun IconicsDrawable.colorString(colorString: String) =
+        color(colorString.toIconicsColor())
 
-inline fun IconicsDrawable.colorString(colorString: String) = color(colorString.toIconicsColor())
-inline fun IconicsDrawable.colorRes(@ColorRes colorRes: Int) = color(colorRes.toIconicsColorRes())
-inline fun IconicsDrawable.colorInt(@ColorInt colorInt: Int) = color(colorInt.toIconicsColor())
+@Deprecated(
+    message = "Moved to new class",
+    replaceWith = ReplaceWith("colorRes", "com.mikepenz.iconics.utils.colorRes")
+)
+inline fun IconicsDrawable.colorRes(@ColorRes colorRes: Int) =
+        color(colorRes.toIconicsColorRes())
 
+@Deprecated(
+    message = "Moved to new class",
+    replaceWith = ReplaceWith("colorInt", "com.mikepenz.iconics.utils.colorInt")
+)
+inline fun IconicsDrawable.colorInt(@ColorInt colorInt: Int) =
+        color(colorInt.toIconicsColor())
+
+@Deprecated(
+    message = "Moved to new class",
+    replaceWith = ReplaceWith("sizeDp", "com.mikepenz.iconics.utils.sizeDp")
+)
 inline fun IconicsDrawable.sizeDp(@Dimension(unit = DP) sizeDp: Int) =
         size(sizeDp.toIconicsSizeDp())
 
+@Deprecated(
+    message = "Moved to new class",
+    replaceWith = ReplaceWith("sizePx", "com.mikepenz.iconics.utils.sizePx")
+)
 inline fun IconicsDrawable.sizePx(@Dimension(unit = PX) sizePx: Int) =
         size(sizePx.toIconicsSizePx())
 
-inline fun IconicsDrawable.sizeRes(@DimenRes sizeRes: Int) = size(sizeRes.toIconicsSizeRes())
+@Deprecated(
+    message = "Moved to new class",
+    replaceWith = ReplaceWith("sizeRes", "com.mikepenz.iconics.utils.sizeRes")
+)
+inline fun IconicsDrawable.sizeRes(@DimenRes sizeRes: Int) =
+        size(sizeRes.toIconicsSizeRes())
 
+@Deprecated(
+    message = "Moved to new class",
+    replaceWith = ReplaceWith("paddingDp", "com.mikepenz.iconics.utils.paddingDp")
+)
 inline fun IconicsDrawable.paddingDp(@Dimension(unit = DP) sizeDp: Int) =
         padding(sizeDp.toIconicsSizeDp())
 
+@Deprecated(
+    message = "Moved to new class",
+    replaceWith = ReplaceWith("paddingPx", "com.mikepenz.iconics.utils.paddingPx")
+)
 inline fun IconicsDrawable.paddingPx(@Dimension(unit = PX) sizePx: Int) =
         padding(sizePx.toIconicsSizePx())
 
-inline fun IconicsDrawable.paddingRes(@DimenRes sizeRes: Int) = padding(sizeRes.toIconicsSizeRes())
+@Deprecated(
+    message = "Moved to new class",
+    replaceWith = ReplaceWith("paddingRes", "com.mikepenz.iconics.utils.paddingRes")
+)
+inline fun IconicsDrawable.paddingRes(@DimenRes sizeRes: Int) =
+        padding(sizeRes.toIconicsSizeRes())

--- a/library-core/src/main/java/com/mikepenz/iconics/context/IconicsAttrsExtractor.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/context/IconicsAttrsExtractor.kt
@@ -22,9 +22,9 @@ import androidx.annotation.RestrictTo
 import androidx.annotation.RestrictTo.Scope.LIBRARY_GROUP
 import androidx.annotation.StyleableRes
 import com.mikepenz.iconics.Iconics
+import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
-import com.mikepenz.iconics.utils.toIconicsColor
-import com.mikepenz.iconics.utils.toIconicsSizePx
+import com.mikepenz.iconics.IconicsSize
 
 /**
  * @author pa.gulko zTrap (30.10.2017)
@@ -88,51 +88,52 @@ class IconicsAttrsExtractor(
             processedIcon = processedIcon.createIfNeeds(context).icon(i)
         }
         typedArray.getColorStateList(colorsId)?.let {
-            processedIcon = processedIcon.createIfNeeds(context).color(it.toIconicsColor())
+            processedIcon = processedIcon.createIfNeeds(context).color(IconicsColor.colorList(it))
         }
         typedArray.getDimensionPixelSize(sizeId)?.let {
-            processedIcon = processedIcon.createIfNeeds(context).size(it.toIconicsSizePx())
+            processedIcon = processedIcon.createIfNeeds(context).size(IconicsSize.px(it))
         }
         typedArray.getDimensionPixelSize(paddingId)?.let {
-            processedIcon = processedIcon.createIfNeeds(context).padding(it.toIconicsSizePx())
+            processedIcon = processedIcon.createIfNeeds(context).padding(IconicsSize.px(it))
         }
         if (extractOffsets) {
             typedArray.getDimensionPixelSize(offsetYId)?.let {
                 processedIcon = processedIcon.createIfNeeds(context)
-                        .iconOffsetY(it.toIconicsSizePx())
+                        .iconOffsetY(IconicsSize.px(it))
             }
             typedArray.getDimensionPixelSize(offsetXId)?.let {
                 processedIcon = processedIcon.createIfNeeds(context)
-                        .iconOffsetX(it.toIconicsSizePx())
+                        .iconOffsetX(IconicsSize.px(it))
             }
         }
         // endregion
         // region contour
         typedArray.getColorStateList(contourColorId)?.let {
-            processedIcon = processedIcon.createIfNeeds(context).contourColor(it.toIconicsColor())
+            processedIcon =
+                    processedIcon.createIfNeeds(context).contourColor(IconicsColor.colorList(it))
         }
         typedArray.getDimensionPixelSize(contourWidthId)?.let {
-            processedIcon = processedIcon.createIfNeeds(context).contourWidth(it.toIconicsSizePx())
+            processedIcon = processedIcon.createIfNeeds(context).contourWidth(IconicsSize.px(it))
         }
         // endregion
         // region background
         typedArray.getColorStateList(backgroundColorId)?.let {
             processedIcon = processedIcon.createIfNeeds(context)
-                    .backgroundColor(it.toIconicsColor())
+                    .backgroundColor(IconicsColor.colorList(it))
         }
         typedArray.getDimensionPixelSize(cornerRadiusId)?.let {
             processedIcon = processedIcon.createIfNeeds(context)
-                    .roundedCorners(it.toIconicsSizePx())
+                    .roundedCorners(IconicsSize.px(it))
         }
         // endregion
         // region background contour
         typedArray.getColorStateList(backgroundContourColorId)?.let {
             processedIcon = processedIcon.createIfNeeds(context)
-                    .backgroundContourColor(it.toIconicsColor())
+                    .backgroundContourColor(IconicsColor.colorList(it))
         }
         typedArray.getDimensionPixelSize(backgroundContourWidthId)?.let {
             processedIcon = processedIcon.createIfNeeds(context)
-                    .backgroundContourWidth(it.toIconicsSizePx())
+                    .backgroundContourWidth(IconicsSize.px(it))
         }
         // endregion
         // region shadow
@@ -146,10 +147,10 @@ class IconicsAttrsExtractor(
                 && shadowDy != null
                 && shadowColor != DEF_COLOR) {
             processedIcon = processedIcon.createIfNeeds(context).shadow(
-                shadowRadius.toIconicsSizePx(),
-                shadowDx.toIconicsSizePx(),
-                shadowDy.toIconicsSizePx(),
-                shadowColor.toIconicsColor()
+                IconicsSize.px(shadowRadius),
+                IconicsSize.px(shadowDx),
+                IconicsSize.px(shadowDy),
+                IconicsColor.colorInt(shadowColor)
             )
         }
         // endregion

--- a/library-core/src/main/java/com/mikepenz/iconics/utils/IconicsConverters.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/utils/IconicsConverters.kt
@@ -18,6 +18,7 @@
 
 package com.mikepenz.iconics.utils
 
+import android.annotation.SuppressLint
 import android.content.res.ColorStateList
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
@@ -29,11 +30,13 @@ import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.IconicsSize
 
 /** Pretty converter to [IconicsSize.dp] */
+@SuppressLint("SupportAnnotationUsage")
 inline fun @receiver:Dimension(unit = Dimension.DP) Number.toIconicsSizeDp(): IconicsSize {
     return IconicsSize.dp(this)
 }
 
 /** Pretty converter to [IconicsSize.px] */
+@SuppressLint("SupportAnnotationUsage")
 inline fun @receiver:Dimension(unit = Dimension.PX) Number.toIconicsSizePx(): IconicsSize {
     return IconicsSize.px(this)
 }

--- a/library-core/src/main/java/com/mikepenz/iconics/utils/IconicsConverters.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/utils/IconicsConverters.kt
@@ -29,42 +29,79 @@ import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.IconicsSize
 
-/** Pretty converter to [IconicsSize.dp] */
-@SuppressLint("SupportAnnotationUsage")
-inline fun @receiver:Dimension(unit = Dimension.DP) Number.toIconicsSizeDp(): IconicsSize {
-    return IconicsSize.dp(this)
-}
+// VARIOUS convenient extension functions for quick common setters
 
-/** Pretty converter to [IconicsSize.px] */
-@SuppressLint("SupportAnnotationUsage")
-inline fun @receiver:Dimension(unit = Dimension.PX) Number.toIconicsSizePx(): IconicsSize {
-    return IconicsSize.px(this)
-}
+inline fun IconicsDrawable.colorString(colorString: String) =
+        color(IconicsColor.parse(colorString))
 
-/** Pretty converter to [IconicsSize.res] */
-inline fun @receiver:DimenRes Int.toIconicsSizeRes(): IconicsSize {
-    return IconicsSize.res(toInt())
-}
+inline fun IconicsDrawable.colorRes(@ColorRes colorRes: Int) =
+        color(IconicsColor.colorRes(colorRes))
 
-/** Pretty converter to [IconicsColor.colorInt] */
-inline fun @receiver:ColorInt Int.toIconicsColor(): IconicsColor {
-    return IconicsColor.colorInt(this)
-}
+inline fun IconicsDrawable.colorInt(@ColorInt colorInt: Int) =
+        color(IconicsColor.colorInt(colorInt))
 
-/** Pretty converter to [IconicsColor.parse] */
-inline fun String.toIconicsColor(): IconicsColor {
-    return IconicsColor.parse(this)
-}
+inline fun IconicsDrawable.contourColorString(colorString: String) =
+        contourColor(IconicsColor.parse(colorString))
 
-/** Pretty converter to [IconicsColor.colorList] */
-inline fun ColorStateList.toIconicsColor(): IconicsColor {
-    return IconicsColor.colorList(this)
-}
+inline fun IconicsDrawable.contourColorRes(@ColorRes colorRes: Int) =
+        contourColor(IconicsColor.colorRes(colorRes))
 
-/** Pretty converter to [IconicsColor.colorRes] */
-inline fun @receiver:ColorRes Int.toIconicsColorRes(): IconicsColor {
-    return IconicsColor.colorRes(this)
-}
+inline fun IconicsDrawable.contourColorInt(@ColorInt colorInt: Int) =
+        contourColor(IconicsColor.colorInt(colorInt))
+
+inline fun IconicsDrawable.backgroundColorString(colorString: String) =
+        backgroundColor(IconicsColor.parse(colorString))
+
+inline fun IconicsDrawable.backgroundColorRes(@ColorRes colorRes: Int) =
+        backgroundColor(IconicsColor.colorRes(colorRes))
+
+inline fun IconicsDrawable.backgroundColorInt(@ColorInt colorInt: Int) =
+        backgroundColor(IconicsColor.colorInt(colorInt))
+
+inline fun IconicsDrawable.backgroundContourColorString(colorString: String) =
+        backgroundContourColor(IconicsColor.parse(colorString))
+
+inline fun IconicsDrawable.backgroundContourColorRes(@ColorRes colorRes: Int) =
+        backgroundContourColor(IconicsColor.colorRes(colorRes))
+
+inline fun IconicsDrawable.backgroundContourColorInt(@ColorInt colorInt: Int) =
+        backgroundContourColor(IconicsColor.colorInt(colorInt))
+
+inline fun IconicsDrawable.sizeDp(@Dimension(unit = Dimension.DP) sizeDp: Int) =
+        size(IconicsSize.dp(sizeDp))
+
+inline fun IconicsDrawable.sizePx(@Dimension(unit = Dimension.PX) sizePx: Int) =
+        size(IconicsSize.px(sizePx))
+
+inline fun IconicsDrawable.sizeRes(@DimenRes sizeRes: Int) =
+        size(IconicsSize.res(sizeRes))
+
+inline fun IconicsDrawable.paddingDp(@Dimension(unit = Dimension.DP) sizeDp: Int) =
+        padding(IconicsSize.dp(sizeDp))
+
+inline fun IconicsDrawable.paddingPx(@Dimension(unit = Dimension.PX) sizePx: Int) =
+        padding(IconicsSize.px(sizePx))
+
+inline fun IconicsDrawable.paddingRes(@DimenRes sizeRes: Int) =
+        padding(IconicsSize.res(sizeRes))
+
+inline fun IconicsDrawable.roundedCornersDp(@Dimension(unit = Dimension.DP) sizeDp: Int) =
+        roundedCorners(IconicsSize.dp(sizeDp))
+
+inline fun IconicsDrawable.roundedCornersPx(@Dimension(unit = Dimension.PX) sizePx: Int) =
+        roundedCorners(IconicsSize.px(sizePx))
+
+inline fun IconicsDrawable.roundedCornersRes(@DimenRes sizeRes: Int) =
+        roundedCorners(IconicsSize.res(sizeRes))
+
+inline fun IconicsDrawable.contourWidthDp(@Dimension(unit = Dimension.DP) sizeDp: Int) =
+        contourWidth(IconicsSize.dp(sizeDp))
+
+inline fun IconicsDrawable.contourWidthPx(@Dimension(unit = Dimension.PX) sizePx: Int) =
+        contourWidth(IconicsSize.px(sizePx))
+
+inline fun IconicsDrawable.contourWidthRes(@DimenRes sizeRes: Int) =
+        contourWidth(IconicsSize.res(sizeRes))
 
 /**
  * Pretty converter to [androidx.core.graphics.drawable.IconCompat]
@@ -73,4 +110,48 @@ inline fun @receiver:ColorRes Int.toIconicsColorRes(): IconicsColor {
  */
 inline fun IconicsDrawable.toAndroidIconCompat(): IconCompat {
     return IconCompat.createWithBitmap(toBitmap())
+}
+
+/** Pretty converter to [IconicsSize.dp] */
+@Deprecated("Use IconicsSize.dp() instead", ReplaceWith("IconicsSize.dp(x)", "com.mikepenz.iconics.IconicsSize"))
+@SuppressLint("SupportAnnotationUsage")
+inline fun @receiver:Dimension(unit = Dimension.DP) Number.toIconicsSizeDp(): IconicsSize {
+    return IconicsSize.dp(this)
+}
+
+/** Pretty converter to [IconicsSize.px] */
+@Deprecated("Use IconicsSize.px() instead", ReplaceWith("IconicsSize.px(x)", "com.mikepenz.iconics.IconicsSize"))
+@SuppressLint("SupportAnnotationUsage")
+inline fun @receiver:Dimension(unit = Dimension.PX) Number.toIconicsSizePx(): IconicsSize {
+    return IconicsSize.px(this)
+}
+
+/** Pretty converter to [IconicsSize.res] */
+@Deprecated("Use IconicsSize.res() instead", ReplaceWith("IconicsSize.res(x)", "com.mikepenz.iconics.IconicsSize"))
+inline fun @receiver:DimenRes Int.toIconicsSizeRes(): IconicsSize {
+    return IconicsSize.res(toInt())
+}
+
+/** Pretty converter to [IconicsColor.colorInt] */
+@Deprecated("Use IconicsColor.colorInt() instead", ReplaceWith("IconicsColor.colorInt(x)", "com.mikepenz.iconics.IconicsColor"))
+inline fun @receiver:ColorInt Int.toIconicsColor(): IconicsColor {
+    return IconicsColor.colorInt(this)
+}
+
+/** Pretty converter to [IconicsColor.parse] */
+@Deprecated("Use IconicsColor.parse() instead", ReplaceWith("IconicsColor.parse(x)", "com.mikepenz.iconics.IconicsColor"))
+inline fun String.toIconicsColor(): IconicsColor {
+    return IconicsColor.parse(this)
+}
+
+/** Pretty converter to [IconicsColor.colorList] */
+@Deprecated("Use IconicsColor.colorList() instead", ReplaceWith("IconicsColor.colorList(x)", "com.mikepenz.iconics.IconicsColor"))
+inline fun ColorStateList.toIconicsColor(): IconicsColor {
+    return IconicsColor.colorList(this)
+}
+
+/** Pretty converter to [IconicsColor.colorRes] */
+@Deprecated("Use IconicsColor.colorRes() instead", ReplaceWith("IconicsColor.colorRes(x)", "com.mikepenz.iconics.IconicsColor"))
+inline fun @receiver:ColorRes Int.toIconicsColorRes(): IconicsColor {
+    return IconicsColor.colorRes(this)
 }


### PR DESCRIPTION
* use sealed class for `IconicsColor` as suggested by: #456
* ContextCompat.getColor retrieves the default color already
* introduce more extension functions to converters …
* deprecate old converters, introduce proper replace rule
* deprecate old extension functions in IconicsDrawable class
* refactor code to make use of new proper extension funcions

cc @AllanWang 