### PR TITLE
Feature/dsl

### DIFF
--- a/library-core/src/main/java/com/mikepenz/iconics/dsl/IconicsDrawableDsl.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/dsl/IconicsDrawableDsl.kt
@@ -2,20 +2,16 @@ package com.mikepenz.iconics.dsl
 
 import android.content.Context
 import com.mikepenz.iconics.IconicsDrawable
-import com.mikepenz.iconics.IconicsExtractor
 import com.mikepenz.iconics.IconicsSize
 import com.mikepenz.iconics.typeface.IIcon
+import com.mikepenz.iconics.utils.colorRes
 
-fun Context.iconicsDrawable(icon: (IconicsIconDsl.() -> IIcon)? = null, block: IconicsDrawable.() -> Unit): IconicsDrawable {
+fun Context.iconicsDrawable(icon: IIcon, block: IconicsDrawableDsl.() -> Unit): IconicsDrawable {
     return IconicsDrawable(this).apply {
-        if (icon != null) {
-            icon(IconicsIconDsl.icon())
-        }
-    }.apply(block)
+        icon(icon)
+        IconicsDrawableDsl(this).apply(block)
+    }
 }
-
-
-object IconicsIconDsl
 
 internal class NonReadablePropertyException : Exception()
 
@@ -24,7 +20,30 @@ internal fun nonReadable(): Nothing = throw NonReadablePropertyException()
 internal const val NON_READABLE = "Non readable property."
 
 class IconicsDrawableDsl(internal val drawable: IconicsDrawable) {
-    var sizeX: IconicsSize = IconicsSize.px(IconicsExtractor.DEF_SIZE)
+
+    fun sizePx(px: Number): IconicsSize = IconicsSize.px(px)
+    fun sizeDp(dp: Number): IconicsSize = IconicsSize.dp(dp)
+    fun sizeRes(res: Int): IconicsSize = IconicsSize.res(res)
+
+    var sizeX: IconicsSize
         @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
         get() = nonReadable()
+        set(value) {
+            drawable.sizeX(value)
+            drawable.colorRes()
+        }
+
+    var sizeY: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.sizeY(value)
+        }
+
+    var size: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.size(value)
+        }
 }

--- a/library-core/src/main/java/com/mikepenz/iconics/dsl/IconicsDrawableDsl.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/dsl/IconicsDrawableDsl.kt
@@ -1,0 +1,30 @@
+package com.mikepenz.iconics.dsl
+
+import android.content.Context
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.IconicsExtractor
+import com.mikepenz.iconics.IconicsSize
+import com.mikepenz.iconics.typeface.IIcon
+
+fun Context.iconicsDrawable(icon: (IconicsIconDsl.() -> IIcon)? = null, block: IconicsDrawable.() -> Unit): IconicsDrawable {
+    return IconicsDrawable(this).apply {
+        if (icon != null) {
+            icon(IconicsIconDsl.icon())
+        }
+    }.apply(block)
+}
+
+
+object IconicsIconDsl
+
+internal class NonReadablePropertyException : Exception()
+
+internal fun nonReadable(): Nothing = throw NonReadablePropertyException()
+
+internal const val NON_READABLE = "Non readable property."
+
+class IconicsDrawableDsl(internal val drawable: IconicsDrawable) {
+    var sizeX: IconicsSize = IconicsSize.px(IconicsExtractor.DEF_SIZE)
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+}

--- a/library-core/src/main/java/com/mikepenz/iconics/dsl/IconicsDrawableDsl.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/dsl/IconicsDrawableDsl.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.IconicsSize
 import com.mikepenz.iconics.typeface.IIcon
-import com.mikepenz.iconics.utils.colorRes
 
 fun Context.iconicsDrawable(icon: IIcon, block: IconicsDrawableDsl.() -> Unit): IconicsDrawable {
     return IconicsDrawable(this).apply {
@@ -30,7 +29,6 @@ class IconicsDrawableDsl(internal val drawable: IconicsDrawable) {
         get() = nonReadable()
         set(value) {
             drawable.sizeX(value)
-            drawable.colorRes()
         }
 
     var sizeY: IconicsSize

--- a/library-core/src/main/java/com/mikepenz/iconics/dsl/IconicsDrawableDsl.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/dsl/IconicsDrawableDsl.kt
@@ -1,6 +1,15 @@
 package com.mikepenz.iconics.dsl
 
 import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.ColorFilter
+import android.graphics.Paint
+import android.graphics.PorterDuff
+import android.graphics.Typeface
+import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
+import androidx.annotation.DimenRes
+import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.IconicsSize
 import com.mikepenz.iconics.typeface.IIcon
@@ -12,17 +21,29 @@ fun Context.iconicsDrawable(icon: IIcon, block: IconicsDrawableDsl.() -> Unit): 
     }
 }
 
+fun Context.iconicsDrawable(icon: String, typeface: Typeface? = null, block: IconicsDrawableDsl.() -> Unit): IconicsDrawable {
+    return IconicsDrawable(this).apply {
+        iconText(icon, typeface)
+        IconicsDrawableDsl(this).apply(block)
+    }
+}
+
 internal class NonReadablePropertyException : Exception()
 
 internal fun nonReadable(): Nothing = throw NonReadablePropertyException()
 
 internal const val NON_READABLE = "Non readable property."
 
-class IconicsDrawableDsl(internal val drawable: IconicsDrawable) {
+open class IconicsDrawableDsl(internal val drawable: IconicsDrawable) {
 
-    fun sizePx(px: Number): IconicsSize = IconicsSize.px(px)
-    fun sizeDp(dp: Number): IconicsSize = IconicsSize.dp(dp)
-    fun sizeRes(res: Int): IconicsSize = IconicsSize.res(res)
+    fun sizePx(size: Number): IconicsSize = IconicsSize.px(size)
+    fun sizeDp(size: Number): IconicsSize = IconicsSize.dp(size)
+    fun sizeRes(@DimenRes size: Int): IconicsSize = IconicsSize.res(size)
+
+    fun colorString(color: String): IconicsColor = IconicsColor.parse(color)
+    fun colorRes(@ColorRes color: Int): IconicsColor = IconicsColor.colorRes(color)
+    fun colorInt(@ColorInt color: Int): IconicsColor = IconicsColor.colorInt(color)
+    fun colorList(color: ColorStateList): IconicsColor = IconicsColor.colorList(color)
 
     var sizeX: IconicsSize
         @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
@@ -43,5 +64,133 @@ class IconicsDrawableDsl(internal val drawable: IconicsDrawable) {
         get() = nonReadable()
         set(value) {
             drawable.size(value)
+        }
+
+    var iconOffsetX: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.iconOffsetX(value)
+        }
+
+    var iconOffsetY: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.iconOffsetY(value)
+        }
+
+    var padding: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.padding(value)
+        }
+
+    var color: IconicsColor
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.color(value)
+        }
+
+    var roundedCornersRx: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.roundedCornersRx(value)
+        }
+
+    var roundedCornerRy: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.roundedCornersRy(value)
+        }
+
+    var roundedCorners: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.roundedCorners(value)
+        }
+
+    var backgroundColor: IconicsColor
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.backgroundColor(value)
+        }
+
+    var contourWidth: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.contourWidth(value)
+        }
+
+    var backgroundContourWidth: IconicsSize
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.backgroundContourWidth(value)
+        }
+
+    var drawContour: Boolean
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.drawContour(value)
+        }
+
+    var drawBackgroundContour: Boolean
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.drawBackgroundContour(value)
+        }
+
+    var colorFilter: ColorFilter?
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.colorFilter(value)
+        }
+
+    var tintList: ColorStateList?
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.setTintList(value)
+        }
+
+    var tintMode: PorterDuff.Mode?
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.setTintMode(value)
+        }
+
+    var style: Paint.Style
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.style(value)
+        }
+
+    var actionBarSize: Boolean
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            if (value) {
+                drawable.actionBar()
+            }
+        }
+
+    var respectFontBounds: Boolean
+        @Deprecated(level = DeprecationLevel.ERROR, message = NON_READABLE)
+        get() = nonReadable()
+        set(value) {
+            drawable.respectFontBounds(value)
         }
 }


### PR DESCRIPTION
Resolves #457 

This is just an example of kotlin dsl, similar to how `materialDrawerKt` does it.

Example:

```kt
fun Context.example(icon: IIcon) {
    iconicsDrawable(icon) {
        sizeX = sizePx(2)
        sizeY = sizeDp(3)
        val getSizeX = sizeX // Fails; only setting allowed
    }
}
```

The main difference is that setters are done by var access instead of functions, and variations (eg `px`, `dp`, `res`), are done once and shared, rather than with new functions for each field.

As it stands, if you plan on supporting function variants (`sizeDp`, `sizePx`, ...) for all fields, the dsl is not really necessary. However, removing such variations would probably make code suggestions easier.

If you plan on keeping your extensions as is, meaning there aren't shortcuts for each field (eg `sizeXDp`, `sizeXPx`), then this might be useful.

Stuff like `sizePx` can be further shortened to `px`. It's just that `res` is shared, so I named it `sizeRes` and added the prefix everywhere to be consistent