### PR TITLE
Add support of auto mirroring on RTL languages

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:theme="@style/MaterialDrawerTheme.Light.DarkToolbar"
+        android:supportsRtl="true"
         tools:ignore="GoogleAppIndexingWarning">
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/app/src/main/res/layout/activity_playground.xml
+++ b/app/src/main/res/layout/activity_playground.xml
@@ -72,11 +72,62 @@
                     android:layout_height="72dp"
                     app:iiv_color="@color/md_red_200"
                     app:iiv_icon="gmd_favorite"
-
                     app:iiv_background_color="@android:color/black"
                     app:iiv_background_contour_color="@android:color/holo_red_light"
                     app:iiv_background_contour_width="4dp"
                     app:iiv_corner_radius="36dp" />
+
+            </LinearLayout>
+            <!--endregion-->
+
+            <!--region IconicsImageView Showcase-->
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="IconicsImageView AutoMirror on RTL" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="1px"
+                android:layout_marginBottom="8dp"
+                android:layout_marginTop="8dp"
+                android:background="#000" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:layoutDirection="rtl">
+
+                <com.mikepenz.iconics.view.IconicsImageView
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:padding="24dp"
+                    app:iiv_icon="gmd_accessible"
+                    app:iiv_automirror="true"/>
+
+                <com.mikepenz.iconics.view.IconicsImageView
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    android:padding="24dp"
+                    app:iiv_icon="gmd_accessible"
+                    app:iiv_automirror="false"/>
+
+                <com.mikepenz.iconics.view.IconicsImageView
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    app:iiv_icon="gmd_accessible"
+                    app:iiv_background_color="@color/md_red_50"
+                    app:iiv_padding="24dp"
+                    app:iiv_automirror="true"/>
+
+                <com.mikepenz.iconics.view.IconicsImageView
+                    android:layout_width="72dp"
+                    android:layout_height="72dp"
+                    app:iiv_icon="gmd_accessible"
+                    app:iiv_background_color="@color/md_red_50"
+                    app:iiv_padding="24dp"
+                    app:iiv_automirror="false"/>
 
             </LinearLayout>
             <!--endregion-->

--- a/iconics-view-library/src/main/java/com/mikepenz/iconics/internal/IconicsViewsAttrsApplier.kt
+++ b/iconics-view-library/src/main/java/com/mikepenz/iconics/internal/IconicsViewsAttrsApplier.kt
@@ -51,7 +51,8 @@ internal object IconicsViewsAttrsApplier {
                 shadowDxId = R.styleable.IconicsImageView_iiv_shadow_dx,
                 shadowDyId = R.styleable.IconicsImageView_iiv_shadow_dy,
                 shadowColorId = R.styleable.IconicsImageView_iiv_shadow_color,
-                animationsId = R.styleable.IconicsImageView_iiv_animations
+                animationsId = R.styleable.IconicsImageView_iiv_animations,
+                autoMirrorId = R.styleable.IconicsImageView_iiv_automirror
             ).extract()
         }
     }
@@ -107,7 +108,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsTextView_iiv_all_shadow_dx,
             shadowDyId = R.styleable.IconicsTextView_iiv_all_shadow_dy,
             shadowColorId = R.styleable.IconicsTextView_iiv_all_shadow_color,
-            animationsId = R.styleable.IconicsTextView_iiv_all_animations
+            animationsId = R.styleable.IconicsTextView_iiv_all_animations,
+            autoMirrorId = R.styleable.IconicsTextView_iiv_all_automirror
         ).extract()
     }
 
@@ -133,7 +135,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsTextView_iiv_start_shadow_dx,
             shadowDyId = R.styleable.IconicsTextView_iiv_start_shadow_dy,
             shadowColorId = R.styleable.IconicsTextView_iiv_start_shadow_color,
-            animationsId = R.styleable.IconicsTextView_iiv_start_animations
+            animationsId = R.styleable.IconicsTextView_iiv_start_animations,
+            autoMirrorId = R.styleable.IconicsTextView_iiv_start_automirror
         ).extract(icon)
     }
 
@@ -159,7 +162,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsTextView_iiv_top_shadow_dx,
             shadowDyId = R.styleable.IconicsTextView_iiv_top_shadow_dy,
             shadowColorId = R.styleable.IconicsTextView_iiv_top_shadow_color,
-            animationsId = R.styleable.IconicsTextView_iiv_top_animations
+            animationsId = R.styleable.IconicsTextView_iiv_top_animations,
+            autoMirrorId = R.styleable.IconicsTextView_iiv_top_automirror
         ).extract(icon)
     }
 
@@ -185,7 +189,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsTextView_iiv_end_shadow_dx,
             shadowDyId = R.styleable.IconicsTextView_iiv_end_shadow_dy,
             shadowColorId = R.styleable.IconicsTextView_iiv_end_shadow_color,
-            animationsId = R.styleable.IconicsTextView_iiv_end_animations
+            animationsId = R.styleable.IconicsTextView_iiv_end_animations,
+            autoMirrorId = R.styleable.IconicsTextView_iiv_end_automirror
         ).extract(icon)
     }
 
@@ -211,7 +216,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsTextView_iiv_bottom_shadow_dx,
             shadowDyId = R.styleable.IconicsTextView_iiv_bottom_shadow_dy,
             shadowColorId = R.styleable.IconicsTextView_iiv_bottom_shadow_color,
-            animationsId = R.styleable.IconicsTextView_iiv_bottom_animations
+            animationsId = R.styleable.IconicsTextView_iiv_bottom_animations,
+            autoMirrorId = R.styleable.IconicsTextView_iiv_bottom_automirror
         ).extract(icon)
     }
     //endregion
@@ -249,7 +255,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsCompoundButton_iiv_unchecked_shadow_dx,
             shadowDyId = R.styleable.IconicsCompoundButton_iiv_unchecked_shadow_dy,
             shadowColorId = R.styleable.IconicsCompoundButton_iiv_unchecked_shadow_color,
-            animationsId = R.styleable.IconicsCompoundButton_iiv_unchecked_animations
+            animationsId = R.styleable.IconicsCompoundButton_iiv_unchecked_animations,
+            autoMirrorId = R.styleable.IconicsCompoundButton_iiv_unchecked_automirror
         ).extractNonNull()
     }
 
@@ -274,7 +281,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsCompoundButton_iiv_checked_shadow_dx,
             shadowDyId = R.styleable.IconicsCompoundButton_iiv_checked_shadow_dy,
             shadowColorId = R.styleable.IconicsCompoundButton_iiv_checked_shadow_color,
-            animationsId = R.styleable.IconicsCompoundButton_iiv_checked_animations
+            animationsId = R.styleable.IconicsCompoundButton_iiv_checked_animations,
+            autoMirrorId = R.styleable.IconicsCompoundButton_iiv_checked_automirror
         ).extractNonNull()
     }
     //endregion
@@ -336,7 +344,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsCheckableTextView_iiv_all_checked_shadow_dx,
             shadowDyId = R.styleable.IconicsCheckableTextView_iiv_all_checked_shadow_dy,
             shadowColorId = R.styleable.IconicsCheckableTextView_iiv_all_checked_shadow_color,
-            animationsId = R.styleable.IconicsCheckableTextView_iiv_all_checked_animations
+            animationsId = R.styleable.IconicsCheckableTextView_iiv_all_checked_animations,
+            autoMirrorId = R.styleable.IconicsCheckableTextView_iiv_all_checked_automirror
         ).extract()
     }
 
@@ -362,7 +371,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsCheckableTextView_iiv_start_checked_shadow_dx,
             shadowDyId = R.styleable.IconicsCheckableTextView_iiv_start_checked_shadow_dy,
             shadowColorId = R.styleable.IconicsCheckableTextView_iiv_start_checked_shadow_color,
-            animationsId = R.styleable.IconicsCheckableTextView_iiv_start_checked_animations
+            animationsId = R.styleable.IconicsCheckableTextView_iiv_start_checked_animations,
+            autoMirrorId = R.styleable.IconicsCheckableTextView_iiv_start_checked_automirror
         ).extract(icon)
     }
 
@@ -388,7 +398,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsCheckableTextView_iiv_top_checked_shadow_dx,
             shadowDyId = R.styleable.IconicsCheckableTextView_iiv_top_checked_shadow_dy,
             shadowColorId = R.styleable.IconicsCheckableTextView_iiv_top_checked_shadow_color,
-            animationsId = R.styleable.IconicsCheckableTextView_iiv_top_checked_animations
+            animationsId = R.styleable.IconicsCheckableTextView_iiv_top_checked_animations,
+            autoMirrorId = R.styleable.IconicsCheckableTextView_iiv_top_checked_automirror
         ).extract(icon)
     }
 
@@ -414,7 +425,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsCheckableTextView_iiv_end_checked_shadow_dx,
             shadowDyId = R.styleable.IconicsCheckableTextView_iiv_end_checked_shadow_dy,
             shadowColorId = R.styleable.IconicsCheckableTextView_iiv_end_checked_shadow_color,
-            animationsId = R.styleable.IconicsCheckableTextView_iiv_end_checked_animations
+            animationsId = R.styleable.IconicsCheckableTextView_iiv_end_checked_animations,
+            autoMirrorId = R.styleable.IconicsCheckableTextView_iiv_end_checked_automirror
         ).extract(icon)
     }
 
@@ -440,7 +452,8 @@ internal object IconicsViewsAttrsApplier {
             shadowDxId = R.styleable.IconicsCheckableTextView_iiv_bottom_checked_shadow_dx,
             shadowDyId = R.styleable.IconicsCheckableTextView_iiv_bottom_checked_shadow_dy,
             shadowColorId = R.styleable.IconicsCheckableTextView_iiv_bottom_checked_shadow_color,
-            animationsId = R.styleable.IconicsCheckableTextView_iiv_bottom_checked_animations
+            animationsId = R.styleable.IconicsCheckableTextView_iiv_bottom_checked_animations,
+            autoMirrorId = R.styleable.IconicsCheckableTextView_iiv_bottom_checked_automirror
         ).extract(icon)
     }
     //endregion

--- a/iconics-view-library/src/main/res/values/attrs.xml
+++ b/iconics-view-library/src/main/res/values/attrs.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2019 Mike Penz
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,6 +34,7 @@
         <attr name="iiv_shadow_dy" format="dimension|reference" />
         <attr name="iiv_shadow_color" format="color|reference" />
         <attr name="iiv_animations" format="string" />
+        <attr name="iiv_automirror" format="boolean" />
     </declare-styleable>
 
     <declare-styleable name="IconicsTextView">
@@ -54,6 +54,7 @@
         <attr name="iiv_start_shadow_dy" format="dimension|reference" />
         <attr name="iiv_start_shadow_color" format="color|reference" />
         <attr name="iiv_start_animations" format="string" />
+        <attr name="iiv_start_automirror" format="boolean" />
         <!--endregion-->
 
         <!--region top icon-->
@@ -72,6 +73,7 @@
         <attr name="iiv_top_shadow_dy" format="dimension|reference" />
         <attr name="iiv_top_shadow_color" format="color|reference" />
         <attr name="iiv_top_animations" format="string" />
+        <attr name="iiv_top_automirror" format="boolean" />
         <!--endregion-->
 
         <!--region end icon-->
@@ -90,6 +92,7 @@
         <attr name="iiv_end_shadow_dy" format="dimension|reference" />
         <attr name="iiv_end_shadow_color" format="color|reference" />
         <attr name="iiv_end_animations" format="string" />
+        <attr name="iiv_end_automirror" format="boolean" />
         <!--endregion-->
 
         <!--region bottom icon-->
@@ -108,6 +111,7 @@
         <attr name="iiv_bottom_shadow_dy" format="dimension|reference" />
         <attr name="iiv_bottom_shadow_color" format="color|reference" />
         <attr name="iiv_bottom_animations" format="string" />
+        <attr name="iiv_bottom_automirror" format="boolean" />
         <!--endregion-->
 
         <!--region all icons-->
@@ -126,6 +130,7 @@
         <attr name="iiv_all_shadow_dy" format="dimension|reference" />
         <attr name="iiv_all_shadow_color" format="color|reference" />
         <attr name="iiv_all_animations" format="string" />
+        <attr name="iiv_all_automirror" format="boolean" />
         <!--endregion-->
     </declare-styleable>
 
@@ -146,6 +151,7 @@
         <attr name="iiv_checked_shadow_dy" format="dimension|reference" />
         <attr name="iiv_checked_shadow_color" format="color|reference" />
         <attr name="iiv_checked_animations" format="string" />
+        <attr name="iiv_checked_automirror" format="boolean" />
         <!--endregion-->
 
         <!--region unchecked icons-->
@@ -164,6 +170,7 @@
         <attr name="iiv_unchecked_shadow_dy" format="dimension|reference" />
         <attr name="iiv_unchecked_shadow_color" format="color|reference" />
         <attr name="iiv_unchecked_animations" format="string" />
+        <attr name="iiv_unchecked_automirror" format="boolean" />
         <!--endregion-->
     </declare-styleable>
 
@@ -184,6 +191,7 @@
         <attr name="iiv_start_checked_shadow_dy" format="dimension|reference" />
         <attr name="iiv_start_checked_shadow_color" format="color|reference" />
         <attr name="iiv_start_checked_animations" format="string" />
+        <attr name="iiv_start_checked_automirror" format="boolean" />
         <!--endregion-->
 
         <!--region top icon-->
@@ -202,6 +210,7 @@
         <attr name="iiv_top_checked_shadow_dy" format="dimension|reference" />
         <attr name="iiv_top_checked_shadow_color" format="color|reference" />
         <attr name="iiv_top_checked_animations" format="string" />
+        <attr name="iiv_top_checked_automirror" format="boolean" />
         <!--endregion-->
 
         <!--region end icon-->
@@ -220,6 +229,7 @@
         <attr name="iiv_end_checked_shadow_dy" format="dimension|reference" />
         <attr name="iiv_end_checked_shadow_color" format="color|reference" />
         <attr name="iiv_end_checked_animations" format="string" />
+        <attr name="iiv_end_checked_automirror" format="boolean" />
         <!--endregion-->
 
         <!--region bottom icon-->
@@ -238,6 +248,7 @@
         <attr name="iiv_bottom_checked_shadow_dy" format="dimension|reference" />
         <attr name="iiv_bottom_checked_shadow_color" format="color|reference" />
         <attr name="iiv_bottom_checked_animations" format="string" />
+        <attr name="iiv_bottom_checked_automirror" format="boolean" />
         <!--endregion-->
 
         <!--region all icons-->
@@ -256,6 +267,7 @@
         <attr name="iiv_all_checked_shadow_dy" format="dimension|reference" />
         <attr name="iiv_all_checked_shadow_color" format="color|reference" />
         <attr name="iiv_all_checked_animations" format="string" />
+        <attr name="iiv_all_checked_automirror" format="boolean" />
         <!--endregion-->
     </declare-styleable>
 

--- a/library-core/src/main/java/com/mikepenz/iconics/context/IconicsAttrsExtractor.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/context/IconicsAttrsExtractor.kt
@@ -55,7 +55,9 @@ class IconicsAttrsExtractor(
     @StyleableRes private var shadowDyId: Int = 0,
     @StyleableRes private var shadowColorId: Int = 0,
 
-    @StyleableRes private var animationsId: Int = 0
+    @StyleableRes private var animationsId: Int = 0,
+
+    @StyleableRes private var autoMirrorId: Int = 0
 ) {
 
     companion object {
@@ -171,6 +173,13 @@ class IconicsAttrsExtractor(
                     .processors(*processors.toTypedArray())
         }
         // endregion
+
+        //region autoMirror
+        val autoMirror = typedArray.getBoolean(autoMirrorId, false)
+        processedIcon = processedIcon.createIfNeeds(context)
+                .autoMirror(autoMirror)
+        // endregion
+
         return processedIcon
     }
 

--- a/library-core/src/main/res/values/attrs.xml
+++ b/library-core/src/main/res/values/attrs.xml
@@ -33,5 +33,6 @@
         <attr name="ico_shadow_dy" format="dimension|reference" />
         <attr name="ico_shadow_color" format="color|reference" />
         <attr name="ico_animations" format="string" />
+        <attr name="ico_automirror" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This PR adds attributes to the core library and the different views to allow mirroring the drawable when the drawable layout direction is RTL.
This depends on layoutDirection field of Drawable class, so it's available on API 17 and higher only.