### PR TITLE
[WIP] Use ContentProvider to register fonts

### DIFF
--- a/app/src/main/res/values/booleans.xml
+++ b/app/src/main/res/values/booleans.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <bool name="is_iconics_content_provider_enabled">false</bool>
+    <bool name="is_iconics_content_provider_enabled">true</bool>
 </resources>

--- a/community-material-typeface-library/src/main/AndroidManifest.xml
+++ b/community-material-typeface-library/src/main/AndroidManifest.xml
@@ -14,4 +14,16 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.mikepenz.iconics.typeface.library.community" />
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.mikepenz.iconics.typeface.library.community">
+
+    <application>
+        <provider
+            android:name="com.mikepenz.iconics.typeface.library.community.material.ContentProvider"
+            android:enabled="@bool/is_iconics_content_provider_enabled"
+            android:authorities="${applicationId}.iconics.community.material.provider"
+            android:exported="false"
+            android:initOrder="100" />
+    </application>
+</manifest>

--- a/community-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/community/material/CommunityMaterial.kt
+++ b/community-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/community/material/CommunityMaterial.kt
@@ -15,8 +15,14 @@
  */
 package com.mikepenz.iconics.typeface.library.community.material
 
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import android.util.Log
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsContextHolder
 import com.mikepenz.iconics.typeface.library.community.R
 import java.util.LinkedList
 
@@ -5129,4 +5135,25 @@ object CommunityMaterial : ITypeface {
 
         override val typeface: ITypeface by lazy { CommunityMaterial }
     }
+}
+
+/**
+ * Content provider to register the community material icons font
+ */
+internal class ContentProvider : ContentProvider() {
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun query(uri: Uri, projection: Array<String>?, selection: String?, selectionArgs: Array<String>?, sortOrder: String?): Cursor? = null
+
+    override fun onCreate(): Boolean {
+        Log.e("TEST", "FONT REGISTERED")
+        IconicsContextHolder.registerFont(CommunityMaterial)
+        return true
+    }
+
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+
+    override fun getType(uri: Uri): String? = null
 }

--- a/library-core/src/main/java/com/mikepenz/iconics/Iconics.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/Iconics.kt
@@ -42,7 +42,6 @@ import java.util.LinkedList
 object Iconics {
 
     private var INIT_DONE = false
-    private val FONTS = HashMap<String, ITypeface>()
     private val PROCESSORS = HashMap<String, Class<out IconicsAnimationProcessor>>()
 
     @JvmField internal val TAG = Iconics::class.java.simpleName
@@ -90,7 +89,7 @@ object Iconics {
      */
     @JvmStatic private fun init(fonts: Map<String, ITypeface>?): Map<String, ITypeface> {
         init()
-        return if (fonts.isNullOrEmpty()) FONTS else fonts
+        return if (fonts.isNullOrEmpty()) IconicsContextHolder.FONTS else fonts
     }
 
     /**
@@ -105,7 +104,7 @@ object Iconics {
      * [android.app.Application.onCreate] via [registerFont].
      */
     @JvmStatic fun markInitDone() {
-        if (FONTS.isEmpty()) {
+        if (IconicsContextHolder.FONTS.isEmpty()) {
             throw IllegalArgumentException(
                 "At least one font needs to be registered first\n" +
                         "    via ${javaClass.canonicalName}.registerFont(Iconics.kt:117)"
@@ -127,7 +126,7 @@ object Iconics {
 
     /** Registers a fonts into the FONTS array for performance */
     @JvmStatic fun registerFont(font: ITypeface): Boolean {
-        FONTS[font.mappingPrefix] = font.validate()
+        IconicsContextHolder.FONTS[font.mappingPrefix] = font.validate()
         return true
     }
 
@@ -161,7 +160,7 @@ object Iconics {
     /** Return all registered FONTS */
     private val registeredFonts: List<ITypeface>
         get() {
-            return FONTS.values.toList()
+            return IconicsContextHolder.FONTS.values.toList()
         }
 
     /** Return all registered FONTS */
@@ -186,7 +185,7 @@ object Iconics {
     /** Tries to find a font by its key in all registered FONTS */
     @JvmStatic fun findFont(key: String, context: Context? = null): ITypeface? {
         init(context)
-        return FONTS[key]
+        return IconicsContextHolder.FONTS[key]
     }
 
     /** Fetches the font from the Typeface of an IIcon */

--- a/library-typeface-api/src/main/java/com/mikepenz/iconics/typeface/IconicsContextHolder.kt
+++ b/library-typeface-api/src/main/java/com/mikepenz/iconics/typeface/IconicsContextHolder.kt
@@ -24,6 +24,8 @@ import android.content.Context
 object IconicsContextHolder {
     private var context: Context? = null
 
+    val FONTS = HashMap<String, ITypeface>()
+
     @JvmStatic var applicationContext: Context
         get() = context ?: errorContextNotInitialized()
         set(value) {
@@ -39,5 +41,17 @@ object IconicsContextHolder {
             append("Usually this happens via an 'IconicsDrawable' usage.")
         }
         throw RuntimeException(message)
+    }
+
+    /** Registers a fonts into the FONTS array for performance */
+    @JvmStatic fun registerFont(font: ITypeface): Boolean {
+        FONTS[font.mappingPrefix] = font.validate()
+        return true
+    }
+
+    /** Perform a basic sanity check for a font. */
+    @JvmStatic private fun ITypeface.validate(): ITypeface {
+        // TODO IconicsPreconditions.checkMappingPrefix(mappingPrefix)
+        return this
     }
 }


### PR DESCRIPTION
- proposed API to auto register (via provider) without using string resources
  - (Potentially) FIX https://github.com/mikepenz/Android-Iconics/issues/503

- This would use android approach to register and won't rely on SPI or anything which may have difficulties with R8

- considerations:
  - how to enable / disable
  - performance impact for many provider?