### PR TITLE
Improve Gradle section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,19 @@
 
 ## 1. Provide the gradle dependency
 ```gradle
-//the core iconics library (without any widgets)
-implementation "com.mikepenz:iconics-core:${latestFastAdapterRelease}"
-implementation "androidx.appcompat:appcompat:${versions.appCompat}"
+
+def latestAndroidIconicsRelease = "5.0.3"
+dependencies {
+    //the core iconics library (without any widgets)
+    implementation "com.mikepenz:iconics-core:${latestAndroidIconicsRelease}"
+    implementation "androidx.appcompat:appcompat:${versions.appCompat}"
+}
 ```
 
 ## 1b. (optional) Add the view's dependency
 ```gradle
 //this adds all ui view widgets (IconicsButton, IconicsImageView, ...)
-implementation "com.mikepenz:iconics-views:${latestFastAdapterRelease}"
+implementation "com.mikepenz:iconics-views:${latestAndroidIconicsRelease}"
 ```
 
 ## 2. Choose your desired fonts (v4+)

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@
 
 ## 1. Provide the gradle dependency
 ```gradle
-
-def latestAndroidIconicsRelease = "5.0.3"
 dependencies {
     //the core iconics library (without any widgets)
     implementation "com.mikepenz:iconics-core:${latestAndroidIconicsRelease}"


### PR DESCRIPTION
I'm wondering if `"...${latestFastAdapterRelease}"` was a typo or the two libraries versions were matching in the past.