### PR TITLE
Release 5.1.0 -> dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 ## Latest releases 🛠
 
-- Kotlin Next Gen | [v5.0.3](https://github.com/mikepenz/Android-Iconics/tree/v5.0.3)
+- Kotlin Next Gen | [v5.1.0](https://github.com/mikepenz/Android-Iconics/tree/v5.1.0)
 - Kotlin  | [v4.0.2](https://github.com/mikepenz/Android-Iconics/tree/v4.0.2)
 - Java AndroidX | [v3.2.5](https://github.com/mikepenz/Android-Iconics/tree/v3.2.5)
 - Java Appcompat | [v3.0.4](https://github.com/mikepenz/Android-Iconics/tree/v3.0.4)
@@ -70,22 +70,26 @@ dependencies {
 implementation "com.mikepenz:iconics-views:${latestAndroidIconicsRelease}"
 ```
 
-## 2. Choose your desired fonts (v4+)
+## 2. Choose your desired fonts
+
+> Note: Fonts ending with `-kotlin` require at least v4.x of Android-Iconics
+> Note: v5.1.x or newer requires the latest font versions
+
 ```gradle
-implementation 'com.mikepenz:google-material-typeface:3.0.1.4.original-kotlin@aar'
-implementation 'com.mikepenz:material-design-iconic-typeface:2.2.0.6-kotlin@aar'
-implementation 'com.mikepenz:fontawesome-typeface:5.9.0.0-kotlin@aar'
-implementation 'com.mikepenz:octicons-typeface:3.2.0.6-kotlin@aar'
-implementation 'com.mikepenz:meteocons-typeface:1.1.0.5-kotlin@aar'
-implementation 'com.mikepenz:community-material-typeface:5.3.45.1-kotlin@aar' // note 5.3.45.1 alphabetically sorts, and merges in 3 sections
-implementation 'com.mikepenz:weather-icons-typeface:2.0.10.5-kotlin@aar'
-implementation 'com.mikepenz:typeicons-typeface:2.0.7.5-kotlin@aar'
-implementation 'com.mikepenz:entypo-typeface:1.0.0.5-kotlin@aar'
-implementation 'com.mikepenz:devicon-typeface:2.0.0.5-kotlin@aar'
-implementation 'com.mikepenz:foundation-icons-typeface:3.0.0.5-kotlin@aar'
-implementation 'com.mikepenz:ionicons-typeface:2.0.1.5-kotlin@aar'
-implementation 'com.mikepenz:pixeden-7-stroke-typeface:1.2.0.3-kotlin@aar'
-implementation 'com.mikepenz:material-design-icons-dx-typeface:5.0.1.0-kotlin@aar'
+implementation 'com.mikepenz:google-material-typeface:3.0.1.5.original-kotlin@aar'
+implementation 'com.mikepenz:community-material-typeface:5.3.45.2-kotlin@aar' // note 5.3.45.1 alphabetically sorts, and merges in 3 sections
+implementation 'com.mikepenz:devicon-typeface:2.0.0.6-kotlin@aar'
+implementation 'com.mikepenz:entypo-typeface:1.0.0.6-kotlin@aar'
+implementation 'com.mikepenz:fontawesome-typeface:5.9.0.1-kotlin@aar'
+implementation 'com.mikepenz:foundation-icons-typeface:3.0.0.6-kotlin@aar'
+implementation 'com.mikepenz:ionicons-typeface:2.0.1.6-kotlin@aar'
+implementation 'com.mikepenz:material-design-icons-dx-typeface:5.0.1.1-kotlin@aar'
+implementation 'com.mikepenz:material-design-iconic-typeface:2.2.0.7-kotlin@aar'
+implementation 'com.mikepenz:meteocons-typeface:1.1.0.6-kotlin@aar'
+implementation 'com.mikepenz:octicons-typeface:3.2.0.7-kotlin@aar'
+implementation 'com.mikepenz:pixeden-7-stroke-typeface:1.2.0.4-kotlin@aar'
+implementation 'com.mikepenz:typeicons-typeface:2.0.7.6-kotlin@aar'
+implementation 'com.mikepenz:weather-icons-typeface:2.0.10.6-kotlin@aar'
 ```
 
 # Usage

--- a/app/src/main/res/layout/activity_playground.xml
+++ b/app/src/main/res/layout/activity_playground.xml
@@ -80,14 +80,14 @@
                         android:layout_width="72dp"
                         android:layout_height="72dp"
                         android:padding="24dp"
-                        android:tint="@color/accent"
+                        app:tint="@color/accent"
                         app:srcCompat="@drawable/gmd_favorite" />
 
                     <ImageView
                         android:layout_width="72dp"
                         android:layout_height="72dp"
                         android:padding="24dp"
-                        android:tint="@color/accent"
+                        app:tint="@color/accent"
                         app:srcCompat="@drawable/gmd_favorite" />
                 </LinearLayout>
                 <!--endregion-->

--- a/app/src/main/res/values-v21/themes.xml
+++ b/app/src/main/res/values-v21/themes.xml
@@ -23,5 +23,10 @@
         <item name="android:windowAllowReturnTransitionOverlap">true</item>
         <item name="android:windowSharedElementEnterTransition">@android:transition/move</item>
         <item name="android:windowSharedElementExitTransition">@android:transition/move</item>
+
+        <item name="android:windowTranslucentStatus">true</item>
+
+        <item name="android:statusBarColor">@color/immersive_bars</item>
+        <item name="android:navigationBarColor">@color/nav_bar</item>
     </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -24,11 +24,6 @@
         <item name="colorPrimaryDark">@color/primary_dark</item>
         <item name="colorAccent">@color/accent</item>
 
-        <item name="android:windowTranslucentStatus">true</item>
-
-        <item name="android:statusBarColor">@color/immersive_bars</item>
-        <item name="android:navigationBarColor">@color/nav_bar</item>
-
         <!-- CAB :D -->
         <item name="windowActionModeOverlay">true</item>
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ buildscript {
 
     ext {
         release = [
-                versionName: "5.0.3",
-                versionCode: 50030
+                versionName: "5.1.0",
+                versionCode: 50100
         ]
 
         setup = [

--- a/community-material-typeface-library/build.gradle
+++ b/community-material-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 53451
-        versionName "5.3.45.1-kotlin"
+        versionCode 53452
+        versionName "5.3.45.2-kotlin"
 
         resValue "string", "community_material_version", "${versionName}"
     }

--- a/devicon-typeface-library/build.gradle
+++ b/devicon-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 20005
-        versionName "2.0.0.5-kotlin"
+        versionCode 20006
+        versionName "2.0.0.6-kotlin"
 
         resValue "string", "devicon_version", "${versionName}"
     }

--- a/entypo-typeface-library/build.gradle
+++ b/entypo-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 10005
-        versionName "1.0.0.5-kotlin"
+        versionCode 10006
+        versionName "1.0.0.6-kotlin"
 
         resValue "string", "entypo_version", "${versionName}"
     }

--- a/fontawesome-typeface-library/build.gradle
+++ b/fontawesome-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 59000
-        versionName "5.9.0.0-kotlin"
+        versionCode 59001
+        versionName "5.9.0.1-kotlin"
 
         resValue "string", "fontawesome_version", "${versionName}"
     }

--- a/foundation-icons-typeface-library/build.gradle
+++ b/foundation-icons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 30005
-        versionName "3.0.0.5-kotlin"
+        versionCode 30006
+        versionName "3.0.0.6-kotlin"
 
         resValue "string", "foundation_version", "${versionName}"
     }

--- a/google-material-typeface-library/build.gradle
+++ b/google-material-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 30014
-        versionName "3.0.1.4.original-kotlin"
+        versionCode 30015
+        versionName "3.0.1.5.original-kotlin"
 
         resValue "string", "googlematerial_version", "${versionName}"
     }

--- a/gradle-release.gradle
+++ b/gradle-release.gradle
@@ -51,7 +51,7 @@ afterEvaluate { project ->
         key = project.hasProperty('bintray.apikey') ? project.property('bintray.apikey') : System.getenv('BINTRAY_API_KEY')
         def gpgkey = project.hasProperty('bintray.gpg.key') ? project.property('bintray.gpg.key') : System.getenv('BINTRAY_GPG_KEY')
         def gpgpass = project.hasProperty('bintray.gpg.password') ? project.property('bintray.gpg.password') : System.getenv('BINTRAY_GPG_PASS')
-        def versionName = project.release.versionName
+        def versionName = android.defaultConfig.versionName
 
         publications('release')
 
@@ -124,7 +124,7 @@ afterEvaluate { project ->
             release(MavenPublication) {
                 groupId GROUP
                 artifactId POM_ARTIFACT_ID
-                version project.release.versionName
+                version android.defaultConfig.versionName
                 artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
                 artifact androidSourcesJar
                 artifact androidJavadocsJar

--- a/ionicons-typeface-library/build.gradle
+++ b/ionicons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 20105
-        versionName "2.0.1.5-kotlin"
+        versionCode 20106
+        versionName "2.0.1.6-kotlin"
 
         resValue "string", "iconics_version", "${versionName}"
     }

--- a/material-design-dx-typeface-library/build.gradle
+++ b/material-design-dx-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 50010
-        versionName "5.0.1.0-kotlin"
+        versionCode 50011
+        versionName "5.0.1.1-kotlin"
 
         resValue "string", "materialdesigndx_version", "${versionName}"
     }

--- a/material-design-iconic-typeface-library/build.gradle
+++ b/material-design-iconic-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 22006
-        versionName "2.2.0.6-kotlin"
+        versionCode 22007
+        versionName "2.2.0.7-kotlin"
 
         resValue "string", "materialdesigniconic_version", "${versionName}"
     }

--- a/meteocons-typeface-library/build.gradle
+++ b/meteocons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 11005
-        versionName "1.1.0.5-kotlin"
+        versionCode 11006
+        versionName "1.1.0.6-kotlin"
 
         resValue "string", "meteocons_version", "${versionName}"
     }

--- a/octicons-typeface-library/build.gradle
+++ b/octicons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 32006
-        versionName "3.2.0.6-kotlin"
+        versionCode 32007
+        versionName "3.2.0.7-kotlin"
 
         resValue "string", "octicons_version", "${versionName}"
     }

--- a/pixeden-7-stroke-typeface-library/build.gradle
+++ b/pixeden-7-stroke-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 12003
-        versionName "1.2.0.3-kotlin"
+        versionCode 12004
+        versionName "1.2.0.4-kotlin"
 
         resValue "string", "pixeden7_version", "${versionName}"
     }

--- a/typeicons-typeface-library/build.gradle
+++ b/typeicons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 20705
-        versionName "2.0.7.5-kotlin"
+        versionCode 20706
+        versionName "2.0.7.6-kotlin"
 
         resValue "string", "typeicons_version", "${versionName}"
     }

--- a/weather-icons-typeface-library/build.gradle
+++ b/weather-icons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 20105
-        versionName "2.0.10.5-kotlin"
+        versionCode 20106
+        versionName "2.0.10.6-kotlin"
 
         resValue "string", "weathericons_version", "${versionName}"
     }


### PR DESCRIPTION
- [release] v5.1.0
- update all font addons to use jetpack app startup
```
implementation 'com.mikepenz:google-material-typeface:3.0.1.5.original-kotlin@aar'
implementation 'com.mikepenz:community-material-typeface:5.3.45.2-kotlin@aar'
implementation 'com.mikepenz:devicon-typeface:2.0.0.6-kotlin@aar'
implementation 'com.mikepenz:entypo-typeface:1.0.0.6-kotlin@aar'
implementation 'com.mikepenz:fontawesome-typeface:5.9.0.1-kotlin@aar'
implementation 'com.mikepenz:foundation-icons-typeface:3.0.0.6-kotlin@aar'
implementation 'com.mikepenz:ionicons-typeface:2.0.1.6-kotlin@aar'
implementation 'com.mikepenz:material-design-icons-dx-typeface:5.0.1.1-kotlin@aar'
implementation 'com.mikepenz:material-design-iconic-typeface:2.2.0.7-kotlin@aar'
implementation 'com.mikepenz:meteocons-typeface:1.1.0.6-kotlin@aar'
implementation 'com.mikepenz:octicons-typeface:3.2.0.7-kotlin@aar'
implementation 'com.mikepenz:pixeden-7-stroke-typeface:1.2.0.4-kotlin@aar'
implementation 'com.mikepenz:typeicons-typeface:2.0.7.6-kotlin@aar'
implementation 'com.mikepenz:weather-icons-typeface:2.0.10.6-kotlin@aar'
```