### PR TITLE
Fix `setState` nullable annotation compile issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,10 @@ buildscript {
         ]
 
         setup = [
-                compileSdk    : 30,
-                compileSdkCore: 28,
-                buildTools    : "30.0.2",
-                minSdk        : 16,
-                targetSdk     : 30
+                compileSdk: 30,
+                buildTools: "30.0.2",
+                minSdk    : 16,
+                targetSdk : 30
         ]
 
         versions = [

--- a/build.gradle
+++ b/build.gradle
@@ -31,22 +31,22 @@ buildscript {
         ]
 
         versions = [
-                kotlin          : '1.4.10',
+                kotlin          : '1.4.20',
                 androidX        : '1.0.0',
                 recyclerView    : '1.1.0',
                 material        : '1.2.1',
                 appcompat       : '1.2.0',
                 drawerlayout    : '1.1.0',
-                constraintLayout: '2.0.2',
+                constraintLayout: '2.0.4',
                 cardview        : '1.0.0',
                 ktx             : [
                         core: '1.3.2'
                 ],
-                startup         : '1.0.0-beta01',
-                detekt          : '1.14.1',
-                aboutLibraries  : '8.4.2',
-                materialDrawer  : '8.1.6',
-                fastAdapter     : '5.2.4'
+                startup         : '1.0.0',
+                detekt          : '1.14.2',
+                aboutLibraries  : '8.6.0',
+                materialDrawer  : '8.1.8',
+                fastAdapter     : '5.3.1'
         ]
     }
 
@@ -59,7 +59,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/library-core/build.gradle
+++ b/library-core/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion setup.compileSdkCore
+    compileSdkVersion setup.compileSdk
     buildToolsVersion setup.buildTools
 
     defaultConfig {

--- a/library-core/src/main/java/com/mikepenz/iconics/IconicsDrawable.kt
+++ b/library-core/src/main/java/com/mikepenz/iconics/IconicsDrawable.kt
@@ -54,7 +54,7 @@ import com.mikepenz.iconics.utils.icon
 import org.xmlpull.v1.XmlPullParser
 
 /** A custom [Drawable] which can display icons from icon fonts. */
-open class IconicsDrawable internal constructor() : Drawable() {
+open class IconicsDrawable internal constructor() : WrappedDrawable() {
 
     internal lateinit var res: Resources
     internal var theme: Theme? = null
@@ -304,6 +304,7 @@ open class IconicsDrawable internal constructor() : Drawable() {
             field = value
             updateShadow()
         }
+
     @ColorInt
     var shadowColorInt = Color.TRANSPARENT
         set(value) {
@@ -452,10 +453,6 @@ open class IconicsDrawable internal constructor() : Drawable() {
                 || tint?.isStateful == true
     }
 
-    // Note `IntArray` here can be null!!
-    // Caused by: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter stateSet
-    //        at com.mikepenz.iconics.IconicsDrawable.setState(IconicsDrawable.kt)
-    // Keep library at Compile 28 to allow nullable type
     override fun setState(stateSet: IntArray?): Boolean {
         return super.setState(stateSet)
                 || iconBrush.isStateful

--- a/library-core/src/main/java/com/mikepenz/iconics/WrappedDrawable.java
+++ b/library-core/src/main/java/com/mikepenz/iconics/WrappedDrawable.java
@@ -1,0 +1,26 @@
+package com.mikepenz.iconics;
+
+import android.graphics.drawable.Drawable;
+
+import androidx.annotation.Nullable;
+
+/**
+ * Note: This wrapper class is required to fix a compile time issue of a non correct nullable annotation in the [Drawable] class.
+ *
+ * @suppress
+ */
+public abstract class WrappedDrawable extends Drawable {
+
+    // Note `IntArray` here can be null!!
+    // Caused by: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkParameterIsNotNull, parameter stateSet
+    //        at com.mikepenz.iconics.IconicsDrawable.setState(IconicsDrawable.kt)
+    // Keep library at Compile 28 to allow nullable type
+    @Override
+    public boolean setState(@Nullable int[] stateSet) {
+        if (stateSet != null) {
+            return super.setState(stateSet);
+        } else {
+            return false;
+        }
+    }
+}

--- a/library-typeface-api/build.gradle
+++ b/library-typeface-api/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion setup.compileSdkCore
+    compileSdkVersion setup.compileSdk
     buildToolsVersion setup.buildTools
 
     defaultConfig {


### PR DESCRIPTION
- fix compile issue by wrapping the drawable class in java 
  - `setState` can be null but is wrongfully annotated as non null in newer android versions