### PR TITLE
Adjust initialiser to not be in the Kotlin `object`, fix API < 28

### DIFF
--- a/community-material-typeface-library/build.gradle
+++ b/community-material-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 53452
-        versionName "5.3.45.2-kotlin"
+        versionCode 53453
+        versionName "5.3.45.3-kotlin"
 
         resValue "string", "community_material_version", "${versionName}"
     }
@@ -37,7 +37,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-
     lintOptions {
         abortOnError false
     }

--- a/community-material-typeface-library/src/main/AndroidManifest.xml
+++ b/community-material-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.community.material.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/community-material-typeface-library/src/main/AndroidManifest.xml
+++ b/community-material-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial"
+                android:name="com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/community-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/community/material/CommunityMaterial.kt
+++ b/community-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/community/material/CommunityMaterial.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.community.material
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import com.mikepenz.iconics.typeface.library.community.R
 import java.util.LinkedList
 
@@ -81,17 +78,6 @@ object CommunityMaterial : ITypeface {
             // ignore error, if not in 1st set, it has to be in the second
         }
         return Icon3.valueOf(key)
-    }
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(CommunityMaterial)
-            return CommunityMaterial
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/community-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/community/material/CommunityMaterial.kt
+++ b/community-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/community/material/CommunityMaterial.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.community.material
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -25,7 +24,7 @@ import com.mikepenz.iconics.typeface.library.community.R
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object CommunityMaterial : ITypeface, Initializer<ITypeface> {
+object CommunityMaterial : ITypeface {
 
     override val fontRes: Int
         get() = R.font.community_material_font_v5_3_45_1
@@ -84,13 +83,15 @@ object CommunityMaterial : ITypeface, Initializer<ITypeface> {
         return Icon3.valueOf(key)
     }
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(CommunityMaterial)
+            return CommunityMaterial
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/community-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/community/material/Initializer.kt
+++ b/community-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/community/material/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.community.material
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(CommunityMaterial)
+        return CommunityMaterial
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/devicon-typeface-library/build.gradle
+++ b/devicon-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 20006
-        versionName "2.0.0.6-kotlin"
+        versionCode 20007
+        versionName "2.0.0.7-kotlin"
 
         resValue "string", "devicon_version", "${versionName}"
     }

--- a/devicon-typeface-library/src/main/AndroidManifest.xml
+++ b/devicon-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.devicon.DevIcon"
+                android:name="com.mikepenz.iconics.typeface.library.devicon.DevIcon$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/devicon-typeface-library/src/main/AndroidManifest.xml
+++ b/devicon-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.devicon.DevIcon$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.devicon.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/devicon-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/devicon/DevIcon.kt
+++ b/devicon-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/devicon/DevIcon.kt
@@ -17,7 +17,6 @@
 package com.mikepenz.iconics.typeface.library.devicon
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -25,7 +24,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object DevIcon : ITypeface, Initializer<ITypeface> {
+object DevIcon : ITypeface {
 
     override val fontRes: Int
         get() = R.font.devicon_font_v2_0_0_1
@@ -68,13 +67,15 @@ object DevIcon : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(DevIcon)
+            return DevIcon
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/devicon-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/devicon/DevIcon.kt
+++ b/devicon-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/devicon/DevIcon.kt
@@ -16,11 +16,8 @@
 
 package com.mikepenz.iconics.typeface.library.devicon
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -66,17 +63,6 @@ object DevIcon : ITypeface {
         get() = "https://github.com/konpa/devicon/blob/master/LICENSE"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(DevIcon)
-            return DevIcon
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         dev_ssh_plain_wordmark('\ue900'),

--- a/devicon-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/devicon/Initializer.kt
+++ b/devicon-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/devicon/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.devicon
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(DevIcon)
+        return DevIcon
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/entypo-typeface-library/build.gradle
+++ b/entypo-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 10006
-        versionName "1.0.0.6-kotlin"
+        versionCode 10007
+        versionName "1.0.0.7-kotlin"
 
         resValue "string", "entypo_version", "${versionName}"
     }

--- a/entypo-typeface-library/src/main/AndroidManifest.xml
+++ b/entypo-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.entypo.Entypo$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.entypo.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/entypo-typeface-library/src/main/AndroidManifest.xml
+++ b/entypo-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.entypo.Entypo"
+                android:name="com.mikepenz.iconics.typeface.library.entypo.Entypo$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/entypo-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/entypo/Entypo.kt
+++ b/entypo-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/entypo/Entypo.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.entypo
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object Entypo : ITypeface, Initializer<ITypeface> {
+object Entypo : ITypeface {
 
     override val fontRes: Int
         get() = R.font.entypo_font_v1_0_0_1
@@ -65,13 +64,15 @@ object Entypo : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(Entypo)
+            return Entypo
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/entypo-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/entypo/Entypo.kt
+++ b/entypo-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/entypo/Entypo.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.entypo
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -63,17 +60,6 @@ object Entypo : ITypeface {
         get() = "https://creativecommons.org/licenses/by-sa/4.0/"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(Entypo)
-            return Entypo
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         ent_add_to_list('\ue900'),

--- a/entypo-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/entypo/Initializer.kt
+++ b/entypo-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/entypo/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.entypo
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(Entypo)
+        return Entypo
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/fontawesome-typeface-library/build.gradle
+++ b/fontawesome-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 59001
-        versionName "5.9.0.1-kotlin"
+        versionCode 59002
+        versionName "5.9.0.2-kotlin"
 
         resValue "string", "fontawesome_version", "${versionName}"
     }

--- a/fontawesome-typeface-library/src/main/AndroidManifest.xml
+++ b/fontawesome-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.fontawesome.FontAwesome"
+                android:name="com.mikepenz.iconics.typeface.library.fontawesome.FontAwesome$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/fontawesome-typeface-library/src/main/AndroidManifest.xml
+++ b/fontawesome-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.fontawesome.FontAwesome$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.fontawesome.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/fontawesome-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/fontawesome/FontAwesome.kt
+++ b/fontawesome-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/fontawesome/FontAwesome.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.fontawesome
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -64,17 +61,6 @@ object FontAwesome : ITypeface {
         get() = "http://scripts.sil.org/OFL"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(FontAwesome)
-            return FontAwesome
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         faw_twitter_square('\uf081'),

--- a/fontawesome-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/fontawesome/FontAwesome.kt
+++ b/fontawesome-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/fontawesome/FontAwesome.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.fontawesome
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object FontAwesome : ITypeface, Initializer<ITypeface> {
+object FontAwesome : ITypeface {
 
     override val fontRes: Int
         get() = R.font.fontawesome_font_v5_9_0
@@ -66,13 +65,15 @@ object FontAwesome : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(FontAwesome)
+            return FontAwesome
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/fontawesome-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/fontawesome/Initializer.kt
+++ b/fontawesome-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/fontawesome/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.fontawesome
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(FontAwesome)
+        return FontAwesome
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/foundation-icons-typeface-library/build.gradle
+++ b/foundation-icons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 30006
-        versionName "3.0.0.6-kotlin"
+        versionCode 30007
+        versionName "3.0.0.7-kotlin"
 
         resValue "string", "foundation_version", "${versionName}"
     }

--- a/foundation-icons-typeface-library/src/main/AndroidManifest.xml
+++ b/foundation-icons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.foundationicons.FoundationIcons"
+                android:name="com.mikepenz.iconics.typeface.library.foundationicons.FoundationIcons$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/foundation-icons-typeface-library/src/main/AndroidManifest.xml
+++ b/foundation-icons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.foundationicons.FoundationIcons$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.foundationicons.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/foundation-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/foundationicons/FoundationIcons.kt
+++ b/foundation-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/foundationicons/FoundationIcons.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.foundationicons
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -63,17 +60,6 @@ object FoundationIcons : ITypeface {
         get() = "https://github.com/zurb/foundation-icons/blob/master/MIT-LICENSE.txt"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(FoundationIcons)
-            return FoundationIcons
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         fou_address_book('\uf100'),

--- a/foundation-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/foundationicons/FoundationIcons.kt
+++ b/foundation-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/foundationicons/FoundationIcons.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.foundationicons
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object FoundationIcons : ITypeface, Initializer<ITypeface> {
+object FoundationIcons : ITypeface {
 
     override val fontRes: Int
         get() = R.font.foundation_icons_font_v3_0_0_1
@@ -65,13 +64,15 @@ object FoundationIcons : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(FoundationIcons)
+            return FoundationIcons
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/foundation-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/foundationicons/Initializer.kt
+++ b/foundation-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/foundationicons/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.foundationicons
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(FoundationIcons)
+        return FoundationIcons
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/google-material-typeface-library/build.gradle
+++ b/google-material-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 30015
-        versionName "3.0.1.5.original-kotlin"
+        versionCode 30016
+        versionName "3.0.1.6.original-kotlin"
 
         resValue "string", "googlematerial_version", "${versionName}"
     }

--- a/google-material-typeface-library/src/main/AndroidManifest.xml
+++ b/google-material-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.googlematerial.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/google-material-typeface-library/src/main/AndroidManifest.xml
+++ b/google-material-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial"
+                android:name="com.mikepenz.iconics.typeface.library.googlematerial.GoogleMaterial$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/google-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/googlematerial/GoogleMaterial.kt
+++ b/google-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/googlematerial/GoogleMaterial.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.googlematerial
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object GoogleMaterial : ITypeface, Initializer<ITypeface> {
+object GoogleMaterial : ITypeface {
 
     override val fontRes: Int
         get() = R.font.google_material_font_v3_0_1_0_original
@@ -66,13 +65,15 @@ object GoogleMaterial : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(GoogleMaterial)
+            return GoogleMaterial
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/google-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/googlematerial/GoogleMaterial.kt
+++ b/google-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/googlematerial/GoogleMaterial.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.googlematerial
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -64,17 +61,6 @@ object GoogleMaterial : ITypeface {
         get() = "http://creativecommons.org/licenses/by/4.0/"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(GoogleMaterial)
-            return GoogleMaterial
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         gmd_3d_rotation('\ue84d'),

--- a/google-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/googlematerial/Initializer.kt
+++ b/google-material-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/googlematerial/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.googlematerial
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(GoogleMaterial)
+        return GoogleMaterial
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/ionicons-typeface-library/build.gradle
+++ b/ionicons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 20106
-        versionName "2.0.1.6-kotlin"
+        versionCode 20107
+        versionName "2.0.1.7-kotlin"
 
         resValue "string", "iconics_version", "${versionName}"
     }

--- a/ionicons-typeface-library/src/main/AndroidManifest.xml
+++ b/ionicons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.ionicons.Ionicons$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.ionicons.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/ionicons-typeface-library/src/main/AndroidManifest.xml
+++ b/ionicons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.ionicons.Ionicons"
+                android:name="com.mikepenz.iconics.typeface.library.ionicons.Ionicons$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/ionicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/ionicons/Initializer.kt
+++ b/ionicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/ionicons/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.ionicons
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(Ionicons)
+        return Ionicons
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/ionicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/ionicons/Ionicons.kt
+++ b/ionicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/ionicons/Ionicons.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.ionicons
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -63,17 +60,6 @@ object Ionicons : ITypeface {
         get() = "https://github.com/driftyco/ionicons/blob/master/LICENSE"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(Ionicons)
-            return Ionicons
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         ion_alert('\uf101'),

--- a/ionicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/ionicons/Ionicons.kt
+++ b/ionicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/ionicons/Ionicons.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.ionicons
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object Ionicons : ITypeface, Initializer<ITypeface> {
+object Ionicons : ITypeface {
 
     override val fontRes: Int
         get() = R.font.ionicons_font_v2_0_1_1
@@ -65,13 +64,15 @@ object Ionicons : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(Ionicons)
+            return Ionicons
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/material-design-dx-typeface-library/build.gradle
+++ b/material-design-dx-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 50011
-        versionName "5.0.1.1-kotlin"
+        versionCode 50012
+        versionName "5.0.1.2-kotlin"
 
         resValue "string", "materialdesigndx_version", "${versionName}"
     }

--- a/material-design-dx-typeface-library/src/main/AndroidManifest.xml
+++ b/material-design-dx-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.materialdesigndx.MaterialDesignDx"
+                android:name="com.mikepenz.iconics.typeface.library.materialdesigndx.MaterialDesignDx$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/material-design-dx-typeface-library/src/main/AndroidManifest.xml
+++ b/material-design-dx-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.materialdesigndx.MaterialDesignDx$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.materialdesigndx.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/material-design-dx-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigndx/Initializer.kt
+++ b/material-design-dx-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigndx/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.materialdesigndx
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(MaterialDesignDx)
+        return MaterialDesignDx
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/material-design-dx-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigndx/MaterialDesignDx.kt
+++ b/material-design-dx-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigndx/MaterialDesignDx.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.materialdesigndx
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object MaterialDesignDx : ITypeface, Initializer<ITypeface> {
+object MaterialDesignDx : ITypeface {
 
     override val fontRes: Int
         get() = R.font.material_design_dx_font_v5_0_1
@@ -65,13 +64,15 @@ object MaterialDesignDx : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(MaterialDesignDx)
+            return MaterialDesignDx
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/material-design-dx-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigndx/MaterialDesignDx.kt
+++ b/material-design-dx-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigndx/MaterialDesignDx.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.materialdesigndx
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -63,17 +60,6 @@ object MaterialDesignDx : ITypeface {
         get() = "https://www.apache.org/licenses/LICENSE-2.0"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(MaterialDesignDx)
-            return MaterialDesignDx
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         gmf_10k('\ue951'),

--- a/material-design-iconic-typeface-library/build.gradle
+++ b/material-design-iconic-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 22007
-        versionName "2.2.0.7-kotlin"
+        versionCode 22008
+        versionName "2.2.0.8-kotlin"
 
         resValue "string", "materialdesigniconic_version", "${versionName}"
     }

--- a/material-design-iconic-typeface-library/src/main/AndroidManifest.xml
+++ b/material-design-iconic-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.materialdesigniconic.MaterialDesignIconic"
+                android:name="com.mikepenz.iconics.typeface.library.materialdesigniconic.MaterialDesignIconic$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/material-design-iconic-typeface-library/src/main/AndroidManifest.xml
+++ b/material-design-iconic-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.materialdesigniconic.MaterialDesignIconic$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.materialdesigniconic.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/material-design-iconic-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigniconic/Initializer.kt
+++ b/material-design-iconic-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigniconic/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.materialdesigniconic
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(MaterialDesignIconic)
+        return MaterialDesignIconic
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/material-design-iconic-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigniconic/MaterialDesignIconic.kt
+++ b/material-design-iconic-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigniconic/MaterialDesignIconic.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.materialdesigniconic
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object MaterialDesignIconic : ITypeface, Initializer<ITypeface> {
+object MaterialDesignIconic : ITypeface {
 
     override val fontRes: Int
         get() = R.font.material_design_iconic_font_v2_2_0
@@ -66,13 +65,15 @@ object MaterialDesignIconic : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(MaterialDesignIconic)
+            return MaterialDesignIconic
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/material-design-iconic-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigniconic/MaterialDesignIconic.kt
+++ b/material-design-iconic-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/materialdesigniconic/MaterialDesignIconic.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.materialdesigniconic
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -64,17 +61,6 @@ object MaterialDesignIconic : ITypeface {
         get() = "http://scripts.sil.org/OFL"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(MaterialDesignIconic)
-            return MaterialDesignIconic
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         //Google material design

--- a/meteocons-typeface-library/build.gradle
+++ b/meteocons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 11006
-        versionName "1.1.0.6-kotlin"
+        versionCode 11007
+        versionName "1.1.0.7-kotlin"
 
         resValue "string", "meteocons_version", "${versionName}"
     }

--- a/meteocons-typeface-library/src/main/AndroidManifest.xml
+++ b/meteocons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.meteoconcs.Meteoconcs$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.meteoconcs.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/meteocons-typeface-library/src/main/AndroidManifest.xml
+++ b/meteocons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.meteoconcs.Meteoconcs"
+                android:name="com.mikepenz.iconics.typeface.library.meteoconcs.Meteoconcs$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/meteocons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/meteoconcs/Initializer.kt
+++ b/meteocons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/meteoconcs/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.meteoconcs
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(Meteoconcs)
+        return Meteoconcs
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/meteocons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/meteoconcs/Meteoconcs.kt
+++ b/meteocons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/meteoconcs/Meteoconcs.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.meteoconcs
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object Meteoconcs : ITypeface, Initializer<ITypeface> {
+object Meteoconcs : ITypeface {
 
     override val fontRes: Int
         get() = R.font.meteocons_v1_1_1
@@ -67,13 +66,15 @@ object Meteoconcs : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(Meteoconcs)
+            return Meteoconcs
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/meteocons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/meteoconcs/Meteoconcs.kt
+++ b/meteocons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/meteoconcs/Meteoconcs.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.meteoconcs
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -65,17 +62,6 @@ object Meteoconcs : ITypeface {
         get() = ""
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(Meteoconcs)
-            return Meteoconcs
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         met_windy_rain_inv('\ue800'),

--- a/octicons-typeface-library/build.gradle
+++ b/octicons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 32007
-        versionName "3.2.0.7-kotlin"
+        versionCode 32008
+        versionName "3.2.0.8-kotlin"
 
         resValue "string", "octicons_version", "${versionName}"
     }

--- a/octicons-typeface-library/src/main/AndroidManifest.xml
+++ b/octicons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.octicons.Octicons$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.octicons.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/octicons-typeface-library/src/main/AndroidManifest.xml
+++ b/octicons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.octicons.Octicons"
+                android:name="com.mikepenz.iconics.typeface.library.octicons.Octicons$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/octicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/octicons/Initializer.kt
+++ b/octicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/octicons/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.octicons
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(Octicons)
+        return Octicons
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/octicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/octicons/Octicons.kt
+++ b/octicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/octicons/Octicons.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.octicons
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -63,17 +60,6 @@ object Octicons : ITypeface {
         get() = "http://scripts.sil.org/OFL"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(Octicons)
-            return Octicons
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         //Octicons

--- a/octicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/octicons/Octicons.kt
+++ b/octicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/octicons/Octicons.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.octicons
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object Octicons : ITypeface, Initializer<ITypeface> {
+object Octicons : ITypeface {
 
     override val fontRes: Int
         get() = R.font.octicons_v3_2_0
@@ -65,13 +64,15 @@ object Octicons : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(Octicons)
+            return Octicons
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/pixeden-7-stroke-typeface-library/build.gradle
+++ b/pixeden-7-stroke-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 12004
-        versionName "1.2.0.4-kotlin"
+        versionCode 12005
+        versionName "1.2.0.5-kotlin"
 
         resValue "string", "pixeden7_version", "${versionName}"
     }

--- a/pixeden-7-stroke-typeface-library/src/main/AndroidManifest.xml
+++ b/pixeden-7-stroke-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.pixeden7stroke.Pixeden7Stroke$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.pixeden7stroke.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/pixeden-7-stroke-typeface-library/src/main/AndroidManifest.xml
+++ b/pixeden-7-stroke-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.pixeden7stroke.Pixeden7Stroke"
+                android:name="com.mikepenz.iconics.typeface.library.pixeden7stroke.Pixeden7Stroke$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/pixeden-7-stroke-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/pixeden7stroke/Initializer.kt
+++ b/pixeden-7-stroke-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/pixeden7stroke/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.pixeden7stroke
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(Pixeden7Stroke)
+        return Pixeden7Stroke
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/pixeden-7-stroke-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/pixeden7stroke/Pixeden7Stroke.kt
+++ b/pixeden-7-stroke-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/pixeden7stroke/Pixeden7Stroke.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.pixeden7stroke
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object Pixeden7Stroke : ITypeface, Initializer<ITypeface> {
+object Pixeden7Stroke : ITypeface {
 
     override val fontRes: Int
         get() = R.font.pixeden_7_stroke_font_v1_2_0
@@ -65,13 +64,15 @@ object Pixeden7Stroke : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(Pixeden7Stroke)
+            return Pixeden7Stroke
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/pixeden-7-stroke-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/pixeden7stroke/Pixeden7Stroke.kt
+++ b/pixeden-7-stroke-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/pixeden7stroke/Pixeden7Stroke.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.pixeden7stroke
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -63,17 +60,6 @@ object Pixeden7Stroke : ITypeface {
         get() = "http://themes-pixeden.com/font-demos/7-stroke/"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(Pixeden7Stroke)
-            return Pixeden7Stroke
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         pe7_7s_album('\ue6aa'),

--- a/typeicons-typeface-library/build.gradle
+++ b/typeicons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 20706
-        versionName "2.0.7.6-kotlin"
+        versionCode 20707
+        versionName "2.0.7.7-kotlin"
 
         resValue "string", "typeicons_version", "${versionName}"
     }

--- a/typeicons-typeface-library/src/main/AndroidManifest.xml
+++ b/typeicons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.typeicons.Typeicons$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.typeicons.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/typeicons-typeface-library/src/main/AndroidManifest.xml
+++ b/typeicons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.typeicons.Typeicons"
+                android:name="com.mikepenz.iconics.typeface.library.typeicons.Typeicons$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/typeicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/typeicons/Initializer.kt
+++ b/typeicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/typeicons/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.typeicons
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(Typeicons)
+        return Typeicons
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/typeicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/typeicons/Typeicons.kt
+++ b/typeicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/typeicons/Typeicons.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.typeicons
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object Typeicons : ITypeface, Initializer<ITypeface> {
+object Typeicons : ITypeface {
 
     override val fontRes: Int
         get() = R.font.typeicons_font_v2_0_7_1
@@ -65,13 +64,15 @@ object Typeicons : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(Typeicons)
+            return Typeicons
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/typeicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/typeicons/Typeicons.kt
+++ b/typeicons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/typeicons/Typeicons.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.typeicons
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -63,17 +60,6 @@ object Typeicons : ITypeface {
         get() = "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(Typeicons)
-            return Typeicons
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         typ_adjust_brightness('\ue000'),

--- a/weather-icons-typeface-library/build.gradle
+++ b/weather-icons-typeface-library/build.gradle
@@ -26,8 +26,8 @@ android {
         minSdkVersion setup.minSdk
         targetSdkVersion setup.targetSdk
         consumerProguardFiles 'consumer-proguard-rules.pro'
-        versionCode 20106
-        versionName "2.0.10.6-kotlin"
+        versionCode 20107
+        versionName "2.0.10.7-kotlin"
 
         resValue "string", "weathericons_version", "${versionName}"
     }

--- a/weather-icons-typeface-library/src/main/AndroidManifest.xml
+++ b/weather-icons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.weathericons.WeatherIcons"
+                android:name="com.mikepenz.iconics.typeface.library.weathericons.WeatherIcons$Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/weather-icons-typeface-library/src/main/AndroidManifest.xml
+++ b/weather-icons-typeface-library/src/main/AndroidManifest.xml
@@ -26,7 +26,7 @@
             android:exported="false"
             tools:node="merge">
             <meta-data
-                android:name="com.mikepenz.iconics.typeface.library.weathericons.WeatherIcons$Initializer"
+                android:name="com.mikepenz.iconics.typeface.library.weathericons.Initializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/weather-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/weathericons/Initializer.kt
+++ b/weather-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/weathericons/Initializer.kt
@@ -1,0 +1,17 @@
+package com.mikepenz.iconics.typeface.library.weathericons
+
+import android.content.Context
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.IconicsHolder
+import com.mikepenz.iconics.typeface.IconicsInitializer
+
+class Initializer : androidx.startup.Initializer<ITypeface> {
+    override fun create(context: Context): ITypeface {
+        IconicsHolder.registerFont(WeatherIcons)
+        return WeatherIcons
+    }
+
+    override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+        return listOf(IconicsInitializer::class.java)
+    }
+}

--- a/weather-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/weathericons/WeatherIcons.kt
+++ b/weather-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/weathericons/WeatherIcons.kt
@@ -16,7 +16,6 @@
 package com.mikepenz.iconics.typeface.library.weathericons
 
 import android.content.Context
-import androidx.startup.Initializer
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.IconicsHolder
@@ -24,7 +23,7 @@ import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
-object WeatherIcons : ITypeface, Initializer<ITypeface> {
+object WeatherIcons : ITypeface {
 
     override val fontRes: Int
         get() = R.font.weather_icons_v2_0_10
@@ -67,13 +66,15 @@ object WeatherIcons : ITypeface, Initializer<ITypeface> {
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
 
-    override fun create(context: Context): ITypeface {
-        IconicsHolder.registerFont(this)
-        return this
-    }
+    class Initializer : androidx.startup.Initializer<ITypeface> {
+        override fun create(context: Context): ITypeface {
+            IconicsHolder.registerFont(WeatherIcons)
+            return WeatherIcons
+        }
 
-    override fun dependencies(): List<Class<out Initializer<*>>> {
-        return listOf(IconicsInitializer::class.java)
+        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
+            return listOf(IconicsInitializer::class.java)
+        }
     }
 
     enum class Icon constructor(override val character: Char) : IIcon {

--- a/weather-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/weathericons/WeatherIcons.kt
+++ b/weather-icons-typeface-library/src/main/java/com/mikepenz/iconics/typeface/library/weathericons/WeatherIcons.kt
@@ -15,11 +15,8 @@
  */
 package com.mikepenz.iconics.typeface.library.weathericons
 
-import android.content.Context
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
-import com.mikepenz.iconics.typeface.IconicsHolder
-import com.mikepenz.iconics.typeface.IconicsInitializer
 import java.util.LinkedList
 
 @Suppress("EnumEntryName")
@@ -65,17 +62,6 @@ object WeatherIcons : ITypeface {
         get() = "http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL"
 
     override fun getIcon(key: String): IIcon = Icon.valueOf(key)
-
-    class Initializer : androidx.startup.Initializer<ITypeface> {
-        override fun create(context: Context): ITypeface {
-            IconicsHolder.registerFont(WeatherIcons)
-            return WeatherIcons
-        }
-
-        override fun dependencies(): List<Class<out androidx.startup.Initializer<*>>> {
-            return listOf(IconicsInitializer::class.java)
-        }
-    }
 
     enum class Icon constructor(override val character: Char) : IIcon {
         wic_day_sunny('\uf00d'),


### PR DESCRIPTION
- move initializer in sub class, not being a object as this fails on API 28
  - FIX https://github.com/mikepenz/Android-Iconics/issues/524