### PR TITLE
Dependency updates | Compose alpha11 compatiblity update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,10 @@ buildscript {
         ]
 
         versions = [
-                kotlin          : '1.4.21',
+                kotlin          : '1.4.21-2',
                 androidX        : '1.0.0',
                 recyclerView    : '1.1.0',
-                material        : '1.2.1',
+                material        : '1.3.0',
                 appcompat       : '1.2.0',
                 drawerlayout    : '1.1.0',
                 constraintLayout: '2.0.4',
@@ -44,11 +44,11 @@ buildscript {
                 ],
                 startup         : '1.0.0',
                 detekt          : '1.15.0',
-                aboutLibraries  : '8.6.3',
+                aboutLibraries  : '8.8.0',
                 materialDrawer  : '8.3.1',
                 fastAdapter     : '5.3.2',
                 // compose
-                compose         : '1.0.0-alpha09'
+                compose         : '1.0.0-alpha11'
         ]
     }
 
@@ -61,7 +61,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha03'
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detekt}"
         classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:${versions.aboutLibraries}"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/iconics-compose/src/main/java/com/mikepenz/iconics/compose/Image.kt
+++ b/iconics-compose/src/main/java/com/mikepenz/iconics/compose/Image.kt
@@ -37,6 +37,7 @@ import com.mikepenz.iconics.typeface.IIcon
 @SuppressLint("ModifierParameter")
 inline fun Image(
     asset: IIcon,
+    contentDescription: String? = asset.name,
     modifier: Modifier = Modifier.size(24.dp),
     iconicsConfig: IconicsConfig = IconicsConfig(),
     alignment: Alignment = Alignment.Center,
@@ -47,6 +48,7 @@ inline fun Image(
     val imagePainter = remember(asset, iconicsConfig) { IconicsPainter(asset, iconicsConfig) }
     Image(
         painter = imagePainter,
+        contentDescription = contentDescription,
         modifier = modifier,
         alignment = alignment,
         contentScale = contentScale,


### PR DESCRIPTION
- update to gradle 6.8.2
- update dependencies to latest stable version
- update to compose-alpha11 and make image compatible again