### PR TITLE
Remove jcenter | Sample app dependency updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -73,8 +73,7 @@ allprojects {
 
     repositories {
         google()
-        jcenter()
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
- update to aboutLibraries 8.8.1
- update materialDrawer to 8.3.2
- update fastAdapter to 5.3.3
- remove jcenter repository