### PR TITLE
Dependency updates | Kotlin 1.4.30 | Compose 1.0.0-alpha12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         ]
 
         versions = [
-                kotlin          : '1.4.21-2',
+                kotlin          : '1.4.30',
                 androidX        : '1.0.0',
                 recyclerView    : '1.1.0',
                 material        : '1.3.0',
@@ -44,11 +44,11 @@ buildscript {
                 ],
                 startup         : '1.0.0',
                 detekt          : '1.15.0',
-                aboutLibraries  : '8.8.0',
-                materialDrawer  : '8.3.1',
+                aboutLibraries  : '8.8.2',
+                materialDrawer  : '8.3.3',
                 fastAdapter     : '5.3.4',
                 // compose
-                compose         : '1.0.0-alpha11'
+                compose         : '1.0.0-alpha12'
         ]
     }
 
@@ -61,7 +61,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha05'
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha07'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:${versions.detekt}"
         classpath "com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:${versions.aboutLibraries}"


### PR DESCRIPTION
- update to Kotlin 1.4.30
- update to aboutLibraries 8.8.2
- update to MaterialDrawer 8.3.3
- update to compose 1.0.0-alpha12
- update gradle build tools alpha07