### PR TITLE
Highlight appcompat:1.4.x emoji support incompatiblity

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,17 @@ Image(
 
 Licenses for all included fonts are linked inside the class or can be found on the coresponding repositories.
 
+# Compatibility Note
+
+### appcompat:1.4.x
+
+Appcompat v1.4.x introduces default enabled emoji support into all `AppCompat*` views, which prevents the `IconicsView*` views (iconics-views module) from properly applying the spannable style.
+To fix this problem, emoji support has to be disabled by doing:
+
+```xml
+app:emojiCompatEnabled="false"
+```
+
 # Advanced Usage
 
 ### Register fonts
@@ -284,7 +295,7 @@ For generating string field for each of icons of your font, you can use this sim
 A awesome gradle plugin which can automatically fetch a font from Fontastic, and generate the Android Module for your project.
 [Iconics-Font-Generator](https://github.com/ligol/IconicsFontGenerator)
 
-# ProGuard
+# ProGuard / R8
 
 ProGuard / R8 rules are bundled internally with each font.
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ To fix this problem, emoji support has to be disabled by doing:
 app:emojiCompatEnabled="false"
 ```
 
+More information on the appcompat emoji support: https://developer.android.com/jetpack/androidx/releases/appcompat#1.4.0-alpha01
+
 # Advanced Usage
 
 ### Register fonts


### PR DESCRIPTION
- add compatibility note on appcompat:1.4.x
  - RELATED https://github.com/mikepenz/Android-Iconics/issues/592