### PR TITLE
Fix setting spanned text to IconicsTextView

### DIFF
--- a/app/src/main/java/com/mikepenz/iconics/sample/PlaygroundActivity.kt
+++ b/app/src/main/java/com/mikepenz/iconics/sample/PlaygroundActivity.kt
@@ -19,15 +19,13 @@ package com.mikepenz.iconics.sample
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
+import android.graphics.Typeface
 import android.graphics.drawable.StateListDrawable
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableString
-import android.text.style.BackgroundColorSpan
-import android.text.style.DynamicDrawableSpan
-import android.text.style.ForegroundColorSpan
-import android.text.style.ImageSpan
-import android.text.style.RelativeSizeSpan
+import android.text.SpannableStringBuilder
+import android.text.style.*
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem
@@ -154,6 +152,17 @@ class PlaygroundActivity : AppCompatActivity() {
             }
         )
         binding.test6.setImageDrawable(iconStateListDrawable)
+
+        val span = SpannableStringBuilder(binding.test10.text)
+        span.setSpan(
+            StyleSpan(Typeface.BOLD),
+            3,
+            6,
+            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+        span.insert(20, "{fab-android}")
+        binding.test10.text = span
+        binding.test10.text = binding.test10.text
 
         val iconicsDrawableBase = IconicsDrawable(this).apply {
             actionBar()

--- a/app/src/main/res/layout/activity_playground.xml
+++ b/app/src/main/res/layout/activity_playground.xml
@@ -261,6 +261,7 @@
                     app:iiv_all_size="24dp" />
 
                 <com.mikepenz.iconics.view.IconicsTextView
+                    android:id="@+id/test10"
                     android:layout_width="wrap_content"
                     android:layout_height="56dp"
                     android:text="abcdefgh{faw-adjust}ijk{fon-test1}lmnopqrstuv{fon-test2}wxyz"

--- a/iconics-core/src/main/java/com/mikepenz/iconics/Iconics.kt
+++ b/iconics-core/src/main/java/com/mikepenz/iconics/Iconics.kt
@@ -334,7 +334,7 @@ object Iconics {
         fun on(on: String): BuilderString = on(SpannableString(on))
 
         /** Defines where the icons should be applied to */
-        fun on(on: CharSequence): BuilderString = on(on.toString())
+        fun on(on: CharSequence): BuilderString = on(SpannableString(on))
 
         /** Defines where the icons should be applied to */
         fun on(on: StringBuilder): BuilderString = on(on.toString())


### PR DESCRIPTION
This PR fixes setting spanned text to `IconicsTextView`, which would just discard the span information before this change. It was caused by converting `CharSequence` to `String` when building Iconics.

A quick comparison is shown below, with a modified PlaygroundActivity (code attached in the commit). A bold span attached to the IconicsTextView is visible.

Note that even calling something like `iconicsTextView.text = iconicsTextView.text` discarded the spans already - making the icons appear as crossed boxes.

The problem probably does not affect normal TextViews, as they do not call the faulty builder method.

![obraz](https://user-images.githubusercontent.com/30433568/136700712-dd616b12-41db-43da-b1b3-bf02e07123b7.png)
