### PR TITLE
Dependency updates 2021.11.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
                 kotlin          : '1.5.31',
                 androidX        : '1.0.0',
                 recyclerView    : '1.2.1',
-                material        : '1.5.0-alpha05',
+                material        : '1.5.0-beta01',
                 appcompat       : '1.3.1',
                 drawerlayout    : '1.1.0',
                 constraintLayout: '2.0.4',
@@ -44,8 +44,8 @@ buildscript {
                 ],
                 startup         : '1.1.0',
                 detekt          : '1.18.1',
-                aboutLibraries  : '10.0.0-a01',
-                materialDrawer  : '9.0.0-a01',
+                aboutLibraries  : '10.0.0-a04',
+                materialDrawer  : '9.0.0-a02',
                 fastAdapter     : '5.5.1',
                 // compose
                 compose         : '1.0.5'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-rc-3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- update materialdrawer and aboutlibraries
- material 1.5.0-beta01
- gradle 7.3