### PR TITLE
[Minor] Fix "Available fonts" table in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,8 @@ Image(
 
 | Link                                                                                                              | Prefix          | Dependency                                                                            |
 |-------------------------------------------------------------------------------------------------------------------|-----------------|---------------------------------------------------------------------------------------|
-| [Google Material Design Icons](https://github.com/google/material-design-icons) **ORIGINAL by
-Google**            | gmd,gmo,gmr,gms | implementation 'com.mikepenz:google-material-typeface{-outlined,rounded,sharp}:+@aar' |
-| [Material Design Iconic Font](http://zavoloklom.github.io/material-design-iconic-font) **Google Material
-Iconic** | gmi             | implementation 'com.mikepenz:material-design-iconic-typeface:+@aar'                   |
+| [Google Material Design Icons](https://github.com/google/material-design-icons) **ORIGINAL by Google**            | gmd,gmo,gmr,gms | implementation 'com.mikepenz:google-material-typeface{-outlined,rounded,sharp}:+@aar' |
+| [Material Design Iconic Font](http://zavoloklom.github.io/material-design-iconic-font) **Google Material Iconic** | gmi             | implementation 'com.mikepenz:material-design-iconic-typeface:+@aar'                   |
 | [Fontawesome](https://fontawesome.com/)                                                                           | faw             | implementation 'com.mikepenz:fontawesome-typeface:+@aar'                              |
 | [FontawesomeBrand](https://fontawesome.com/)                                                                      | fab             | implementation 'com.mikepenz:fontawesome-typeface:+@aar'                              |
 | [FontawesomeRegular](https://fontawesome.com/)                                                                    | far             | implementation 'com.mikepenz:fontawesome-typeface:+@aar'                              |


### PR DESCRIPTION
Previously the first cell of the first two rows was split across two rows due to the extraneous newline in the code.