### PR TITLE
Give Kotlin compiler 8GB of RAM

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,5 @@ android.useAndroidX=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+
+kotlin.daemon.jvmargs=-Xmx8g


### PR DESCRIPTION
Because with less (I tried 4GB as well) it fails with `Not enough memory to run compilation. Try to increase it via 'gradle.properties'.`