### PR TITLE
IconicsMenuInflaterUtil: don't unset non-iconics menu item icons

### DIFF
--- a/iconics-core/src/main/java/com/mikepenz/iconics/utils/IconicsMenuInflaterUtil.kt
+++ b/iconics-core/src/main/java/com/mikepenz/iconics/utils/IconicsMenuInflaterUtil.kt
@@ -168,9 +168,17 @@ object IconicsMenuInflaterUtil {
         menu: Menu
     ) {
         val attrsMap = mutableMapOf<String, String>()
+        var hasIconicsAttrs = false
         repeat(attrs.attributeCount) {
-            attrsMap[attrs.getAttributeName(it)] = attrs.getAttributeValue(it)
+            val name = attrs.getAttributeName(it)
+            attrsMap[name] = attrs.getAttributeValue(it)
+            if (name.startsWith("ico_")) {
+                hasIconicsAttrs = true
+            }
         }
+
+        // Don't unset non-iconics menu item icon
+        if (!hasIconicsAttrs) return
 
         attrsMap["id"]
                 ?.replace("@", "")


### PR DESCRIPTION
I've been testing the Java equivalent of this for about a week and it works fine.

2 considerations:
- Would break if the attributes are renamed to not start with `ico_` (ok since library is very stable)
- A "cleaner" fix might be to ensure IconicsAttrsExtractor returns null if no attrs are specified, but I wanted to avoid potential behaviour changes

Fixes https://github.com/mikepenz/Android-Iconics/issues/666