### PR TITLE
fix(core): don't overwrite existing icons when no ico_ attribute is set

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -69,6 +69,12 @@ android {
         abortOnError false
     }
 
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
     packagingOptions {
         exclude 'META-INF/library-core_release.kotlin_module'
         exclude 'META-INF/library_release.kotlin_module'
@@ -139,4 +145,6 @@ dependencies {
     implementation project(':weather-icons-typeface-library')
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.robolectric:robolectric:4.16'
+    testImplementation 'androidx.test:core:1.7.0'
 }

--- a/app/src/main/res/menu/menu_playground.xml
+++ b/app/src/main/res/menu/menu_playground.xml
@@ -31,4 +31,10 @@
         app:ico_color="@android:color/holo_blue_bright"
         app:ico_icon="gmd_star"
         app:ico_size="24dp" />
+
+    <!-- neither an `android:icon` nor any `ico_*` attribute: must stay without an icon -->
+    <item
+        android:id="@+id/menu_item_3"
+        android:title="Item 3"
+        app:showAsAction="always" />
 </menu>

--- a/app/src/test/java/com/mikepenz/iconics/sample/IconicsMenuInflaterUtilTest.kt
+++ b/app/src/test/java/com/mikepenz/iconics/sample/IconicsMenuInflaterUtilTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 Mike Penz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mikepenz.iconics.sample
+
+import android.app.Activity
+import android.view.Menu
+import androidx.appcompat.view.menu.MenuBuilder
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.IconicsMenuInflaterUtil
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * `menu_playground` covers the three relevant cases:
+ * - `menu_item_1` has a plain `android:icon` and no `ico_*` attributes
+ * - `menu_item_2` is defined via `ico_*` attributes
+ * - `menu_item_3` has no icon at all
+ */
+@RunWith(RobolectricTestRunner::class)
+class IconicsMenuInflaterUtilTest {
+
+    private lateinit var activity: Activity
+    private lateinit var menu: Menu
+
+    @Before fun setUp() {
+        activity = Robolectric.buildActivity(PlaygroundActivity::class.java).get()
+        menu = MenuBuilder(activity)
+    }
+
+    @Test fun `iconics item gets an IconicsDrawable`() {
+        IconicsMenuInflaterUtil.inflate(activity.menuInflater, activity, R.menu.menu_playground, menu)
+
+        assertTrue(menu.findItem(R.id.menu_item_2).icon is IconicsDrawable)
+    }
+
+    @Test fun `non-iconics item keeps its android icon`() {
+        activity.menuInflater.inflate(R.menu.menu_playground, menu)
+        val original = menu.findItem(R.id.menu_item_1).icon
+        assertNotNull("menu_item_1 is expected to declare an android:icon", original)
+
+        IconicsMenuInflaterUtil.parseXmlAndSetIconicsDrawables(activity, R.menu.menu_playground, menu)
+
+        assertSame(
+            "an item without ico_* attributes must keep the drawable of its android:icon",
+            original,
+            menu.findItem(R.id.menu_item_1).icon
+        )
+    }
+
+    @Test fun `item without any icon stays without one`() {
+        IconicsMenuInflaterUtil.inflate(activity.menuInflater, activity, R.menu.menu_playground, menu)
+
+        assertNull(menu.findItem(R.id.menu_item_3).icon)
+    }
+}

--- a/iconics-core/src/main/java/com/mikepenz/iconics/context/IconicsAttrsApplier.kt
+++ b/iconics-core/src/main/java/com/mikepenz/iconics/context/IconicsAttrsApplier.kt
@@ -45,6 +45,11 @@ object IconicsAttrsApplier {
 
     @JvmStatic fun getIconicsDrawable(res: Resources, theme: Theme?, attrs: AttributeSet?): IconicsDrawable? {
         return theme?.obtainStyledAttributes(attrs, R.styleable.Iconics, 0, 0)?.use {
+            // no `ico_*` attribute at all -> there is nothing to build an icon from. Returning an
+            // empty drawable here would overwrite whatever icon the target already has, e.g. the
+            // `android:icon` of a menu item or the `android:src` of an `ImageView`.
+            if (it.indexCount == 0) return@use null
+
             IconicsAttrsExtractor(
                 res = res,
                 theme = theme,

--- a/iconics-core/src/main/java/com/mikepenz/iconics/utils/IconicsMenuInflaterUtil.kt
+++ b/iconics-core/src/main/java/com/mikepenz/iconics/utils/IconicsMenuInflaterUtil.kt
@@ -168,17 +168,9 @@ object IconicsMenuInflaterUtil {
         menu: Menu
     ) {
         val attrsMap = mutableMapOf<String, String>()
-        var hasIconicsAttrs = false
         repeat(attrs.attributeCount) {
-            val name = attrs.getAttributeName(it)
-            attrsMap[name] = attrs.getAttributeValue(it)
-            if (name.startsWith("ico_")) {
-                hasIconicsAttrs = true
-            }
+            attrsMap[attrs.getAttributeName(it)] = attrs.getAttributeValue(it)
         }
-
-        // Don't unset non-iconics menu item icon
-        if (!hasIconicsAttrs) return
 
         attrsMap["id"]
                 ?.replace("@", "")


### PR DESCRIPTION
Follow-up on top of #667, which fixed the reported symptom (#666). Same bug, addressed one layer down so it covers every call site.

## Root cause

`IconicsAttrsApplier.getIconicsDrawable()` is declared nullable and all three call sites treat `null` as "no iconics data here, leave the target alone":

```kotlin
IconicsAttrsApplier.getIconicsDrawable(context, attrs)?.let { menuItem.icon = it }
```

But it never returns `null`. `IconicsAttrsExtractor.extract()` ends in `createIfNeeds()`, so an `AttributeSet` with no `ico_*` attribute still yields an empty `IconicsDrawable` — and that empty drawable then replaces whatever icon the target already had.

That is why a menu item declaring only `android:icon` came back blank. The same applies to the `ActionMenuItemView` and `ImageView` branches of `IconicsFactory`, so an `android:src` is clobbered too whenever `IconicsLayoutInflater` is in use — which #667's menu-inflater-local fix does not reach.

## Changes

Return `null` when the obtained `TypedArray` holds none of the styleable's attributes:

```kotlin
if (it.indexCount == 0) return@use null
```

`R.styleable.Iconics` contains only `ico_*` attributes, so `indexCount == 0` means exactly "this tag declares no iconics data". No behaviour change for anything that does declare one.

With that in place the `name.startsWith("ico_")` check from #667 is redundant, and is removed in the second commit — the author flagged it as brittle under attribute renames, and it covered the menu inflater only.

## Tests

`app/src/test/.../IconicsMenuInflaterUtilTest.kt`, Robolectric, over the existing `menu_playground` resource, which already had the two interesting cases and now also has an item with no icon at all:

- `menu_item_1` — plain `android:icon`, no `ico_*` → drawable must be left untouched (asserted by identity)
- `menu_item_2` — `ico_icon`/`ico_color`/`ico_size` → must become an `IconicsDrawable`
- `menu_item_3` — no icon at all → must stay without one

Both regression tests fail with the fix reverted and pass with it. This is the first unit test in the repo, so it also brings in Robolectric and `includeAndroidResources` for the app module.